### PR TITLE
Updated default Vue App to use js and not ts

### DIFF
--- a/src/templates/vue/index.js
+++ b/src/templates/vue/index.js
@@ -12,7 +12,7 @@ export const vueIndexAppVue = `
     </div>
 </template>
 
-<script lang="ts">
+<script lang="js">
   import HelloComponent from "./Hello.vue";
   import Vue from "vue";
 


### PR DESCRIPTION
File: src\templates\vue\index.js
const vueIndexAppVue

description: Updated default Vue App to use js and not ts