### PR TITLE
Added ESLint and git pre-hooks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,29 @@
+{
+  "extends": ["airbnb", "plugin:prettier/recommended", "prettier/react"],
+  "parser": "babel-eslint",
+  "env": {
+    "browser": true,
+    "commonjs": true,
+    "es6": true,
+    "jest": true,
+    "node": true
+  },
+  "rules": {
+    "jsx-a11y/href-no-hash": ["off"],
+    "react/jsx-filename-extension": ["warn", { "extensions": [".js", ".jsx"] }],
+    "max-len": [
+      "warn",
+      {
+        "code": 80,
+        "tabWidth": 2,
+        "comments": 80,
+        "ignoreComments": false,
+        "ignoreTrailingComments": true,
+        "ignoreUrls": true,
+        "ignoreStrings": true,
+        "ignoreTemplateLiterals": true,
+        "ignoreRegExpLiterals": true
+      }
+    ]
+  }
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,13 @@
 {
   "extends": ["airbnb", "plugin:prettier/recommended", "prettier/react"],
   "parser": "babel-eslint",
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true
+    }
+  },
   "env": {
     "browser": true,
     "commonjs": true,
@@ -11,8 +18,41 @@
   "rules": {
     "jsx-a11y/href-no-hash": ["off"],
     "react/jsx-filename-extension": ["warn", { "extensions": [".js", ".jsx"] }],
+    "import/prefer-default-export": ["off"],
+    "react/no-unescaped-entities": ["off"],
+    "global-require": ["off"],
+    "react/prop-types": ["off"],
+    "max-classes-per-file": ["off"],
+    "no-unused-vars": ["off"],
+    "no-shadow": ["off"],
+    "jsx-a11y/click-events-have-key-events": ["off"],
+    "jsx-a11y/no-noninteractive-element-interactions": ["off"],
+    "react/destructuring-assignment": ["off"],
+    "react/no-did-update-set-state": ["off"],
+    "react/sort-comp": ["off"],
+    "jsx-a11y/no-autofocus": ["off"],
+    "react/button-has-type": ["off"],
+    "react/jsx-props-no-spreading": ["off"],
+    "jsx-a11y/label-has-associated-control": ["off"],
+    "jsx-a11y/no-static-element-interactions": ["off"],
+    "react/prefer-stateless-function": ["off"],
+    "import/no-extraneous-dependencies": ["off"],
+    "prefer-destructuring": ["off"],
+    "no-nested-ternary": ["off"],
+    "no-use-before-define": ["off"],
+    "no-param-reassign": ["off"],
+    "spaced-comment": ["off"],
+    "prettier/prettier": ["off"],
+    "no-else-return": ["off"],
+    "prefer-template": ["off"],
+    "func-names": ["off"],
+    "no-console": ["off"],
+    "import/no-dynamic-require": ["off"],
+    "no-case-declarations": ["off"],
+    "new-cap": ["off"],
+    "class-methods-use-this": ["off"],
     "max-len": [
-      "warn",
+      "off",
       {
         "code": 80,
         "tabWidth": 2,

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,5 @@
 {
-  "semi": false,
+  "printWidth": 80,
   "singleQuote": true,
   "trailingComma": "es5"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4015,6 +4015,21 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@sindresorhus/is": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+      "dev": true
+    },
+    "@szmarczak/http-timer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+      "dev": true,
+      "requires": {
+        "defer-to-connect": "^1.0.1"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
@@ -4746,6 +4761,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+    },
+    "async-exit-hook": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
+      "dev": true,
+      "optional": true
     },
     "async-limiter": {
       "version": "1.0.0",
@@ -5581,6 +5603,13 @@
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
     },
+    "builtins": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
+      "dev": true,
+      "optional": true
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -5672,6 +5701,44 @@
         "lockfile": "^1.0.4"
       }
     },
+    "cacheable-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+      "dev": true,
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^3.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^1.0.2"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "lowercase-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+          "dev": true
+        },
+        "normalize-url": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+          "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+          "dev": true
+        }
+      }
+    },
     "call-me-maybe": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
@@ -5707,6 +5774,18 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
       "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+    },
+    "camelcase-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+      "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "camelcase": "^4.1.0",
+        "map-obj": "^2.0.0",
+        "quick-lru": "^1.0.0"
+      }
     },
     "caniuse-api": {
       "version": "3.0.0",
@@ -5994,6 +6073,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
       "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
     },
     "clone-stats": {
       "version": "1.0.0",
@@ -6983,6 +7071,26 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -7089,6 +7197,12 @@
           "dev": true
         }
       }
+    },
+    "defer-to-connect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
+      "integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw==",
+      "dev": true
     },
     "define-properties": {
       "version": "1.1.3",
@@ -8032,6 +8146,175 @@
       "integrity": "sha512-Mmmc9lIY/qvX6OEV09+ZLqVTz1aX8VVCrgCjBHXdmMGaC+pldD+87oj3BiJWXMSfcYs5iOo9gy0mGnQ8f/fMsQ==",
       "requires": {
         "confusing-browser-globals": "^1.0.5"
+      }
+    },
+    "eslint-formatter-summary": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-summary/-/eslint-formatter-summary-1.0.4.tgz",
+      "integrity": "sha512-DZRWaDhQ/3A6kgvlWbX8+kymnoPQkD259DpczY61VdcQobFuaEhyp8HeWvrpT/7qh3bRba+sHsJwa3aOusJZwQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "core-js": "^3.1.4",
+        "np": "^5.0.3",
+        "yargs": "^13.3.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "core-js": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.2.tgz",
+          "integrity": "sha512-S1FfZpeBchkhyoY76YAdFzKS4zz9aOK7EeFaNA2aJlyXyA+sgqz6xdxmLPGXEAf0nF44MVN1kSjrA9Kt3ATDQg==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "13.3.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+          "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
       }
     },
     "eslint-import-resolver-node": {
@@ -10390,6 +10673,13 @@
         }
       }
     },
+    "github-url-from-git": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
+      "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA=",
+      "dev": true,
+      "optional": true
+    },
     "glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -10776,6 +11066,12 @@
           }
         }
       }
+    },
+    "has-yarn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
+      "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
+      "dev": true
     },
     "hash-base": {
       "version": "3.0.4",
@@ -11187,6 +11483,12 @@
         }
       }
     },
+    "http-cache-semantics": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
+      "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==",
+      "dev": true
+    },
     "http-deceiver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
@@ -11499,11 +11801,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -11516,15 +11820,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -11627,7 +11934,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -11637,6 +11945,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -11649,6 +11958,7 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -11748,7 +12058,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -11758,6 +12069,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -11863,6 +12175,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -12462,6 +12775,15 @@
       "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz",
       "integrity": "sha1-B7bCM7w5TNnQK6FclmvWZg1jQtU="
     },
+    "is-scoped": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-scoped/-/is-scoped-2.1.0.tgz",
+      "integrity": "sha512-Cv4OpPTHAK9kHYzkzCrof3VJh7H/PrG2MBUMvvJebaaUMbqhm0YAtXnvh0I3Hnj2tMZWwrRROWLSgfJrKqWmlQ==",
+      "dev": true,
+      "requires": {
+        "scoped-regex": "^2.0.0"
+      }
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -12502,6 +12824,36 @@
       "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
       "dev": true
     },
+    "is-url-superb": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-3.0.0.tgz",
+      "integrity": "sha512-3faQP+wHCGDQT1qReM5zCPx2mxoal6DzbzquFlCYJLWyy4WPTved33ea2xFbX37z4NoriEwZGIYhFtx8RUB5wQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "url-regex": "^5.0.0"
+      },
+      "dependencies": {
+        "ip-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.1.0.tgz",
+          "integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA==",
+          "dev": true,
+          "optional": true
+        },
+        "url-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-5.0.0.tgz",
+          "integrity": "sha512-O08GjTiAFNsSlrUWfqF1jH0H1W3m35ZyadHrGv5krdnmPPoxP27oDTqux/579PtaroiSGm5yma6KT1mHFH6Y/g==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ip-regex": "^4.1.0",
+            "tlds": "^1.203.0"
+          }
+        }
+      }
+    },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
@@ -12526,6 +12878,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+    },
+    "is-yarn-global": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+      "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
+      "dev": true,
+      "optional": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -12574,6 +12933,13 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "issue-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/issue-regex/-/issue-regex-2.0.0.tgz",
+      "integrity": "sha512-flaQ/45dMqCYSMzBQI/h3bcto6T70uN7kjNnI8n3gQU6no5p+QcnMWBNXkraED0YvbUymxKaqdvgPa09RZQM5A==",
+      "dev": true,
+      "optional": true
     },
     "istanbul-lib-coverage": {
       "version": "2.0.3",
@@ -13663,6 +14029,12 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
+    "json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+      "dev": true
+    },
     "json-loader": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
@@ -13790,6 +14162,15 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
       "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s="
+    },
+    "keyv": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+      "dev": true,
+      "requires": {
+        "json-buffer": "3.0.0"
+      }
     },
     "killable": {
       "version": "1.0.1",
@@ -14269,6 +14650,106 @@
         }
       }
     },
+    "listr-input": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/listr-input/-/listr-input-0.1.3.tgz",
+      "integrity": "sha512-dvjSD1MrWGXxxPixpMQlSBmkyqhJrPxGo30un25k/vlvFOWZj70AauU+YkEh7CA8vmpkE6Wde37DJDmqYqF39g==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "inquirer": "^3.3.0",
+        "rxjs": "^5.5.2",
+        "through": "^2.3.8"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true,
+          "optional": true
+        },
+        "chardet": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+          "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+          "dev": true,
+          "optional": true
+        },
+        "external-editor": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chardet": "^0.4.0",
+            "iconv-lite": "^0.4.17",
+            "tmp": "^0.0.33"
+          }
+        },
+        "inquirer": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.0.4",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rx-lite": "^4.0.8",
+            "rx-lite-aggregates": "^4.0.8",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "rxjs": {
+          "version": "5.5.12",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+          "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "symbol-observable": "1.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "symbol-observable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+          "dev": true,
+          "optional": true
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        }
+      }
+    },
     "listr-silent-renderer": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
@@ -14605,6 +15086,13 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
+    "lodash.zip": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
+      "integrity": "sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=",
+      "dev": true,
+      "optional": true
+    },
     "log-symbols": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -14756,6 +15244,13 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+    },
+    "map-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+      "dev": true,
+      "optional": true
     },
     "map-visit": {
       "version": "1.0.0",
@@ -14910,6 +15405,99 @@
         "readable-stream": "^2.0.1"
       }
     },
+    "meow": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
+      "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "camelcase-keys": "^4.0.0",
+        "decamelize-keys": "^1.0.0",
+        "loud-rejection": "^1.0.0",
+        "minimist-options": "^3.0.1",
+        "normalize-package-data": "^2.3.4",
+        "read-pkg-up": "^3.0.0",
+        "redent": "^2.0.0",
+        "trim-newlines": "^2.0.0",
+        "yargs-parser": "^10.0.0"
+      },
+      "dependencies": {
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
+      }
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -15051,6 +15639,17 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "minimist-options": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+      "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0"
+      }
     },
     "minipass": {
       "version": "2.3.5",
@@ -15411,6 +16010,927 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
       "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
     },
+    "np": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/np/-/np-5.1.1.tgz",
+      "integrity": "sha512-P0lZvAhcbLkSczR8YewU5uasyZSemVR6mRbxHH+vkLXvG3BNBm5bQFH7fA0KD0apUKEMRoH5Cy0B7d0LpwOPKg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@samverschueren/stream-to-observable": "^0.3.0",
+        "any-observable": "^0.4.0",
+        "async-exit-hook": "^2.0.1",
+        "chalk": "^2.3.0",
+        "cosmiconfig": "^5.2.1",
+        "del": "^4.1.0",
+        "escape-string-regexp": "^2.0.0",
+        "execa": "^2.0.1",
+        "github-url-from-git": "^1.5.0",
+        "has-yarn": "^2.1.0",
+        "hosted-git-info": "^3.0.0",
+        "inquirer": "^7.0.0",
+        "is-installed-globally": "^0.2.0",
+        "is-scoped": "^2.1.0",
+        "issue-regex": "^2.0.0",
+        "listr": "^0.14.3",
+        "listr-input": "^0.1.3",
+        "log-symbols": "^3.0.0",
+        "meow": "^5.0.0",
+        "npm-name": "^5.4.0",
+        "onetime": "^5.1.0",
+        "open": "^6.1.0",
+        "ow": "^0.13.2",
+        "p-memoize": "^3.1.0",
+        "p-timeout": "^3.1.0",
+        "pkg-dir": "^4.1.0",
+        "read-pkg-up": "^6.0.0",
+        "rxjs": "^6.3.3",
+        "semver": "^6.1.2",
+        "split": "^1.0.0",
+        "symbol-observable": "^1.2.0",
+        "terminal-link": "^2.0.0",
+        "update-notifier": "^3.0.0"
+      },
+      "dependencies": {
+        "@types/glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@types/events": "*",
+            "@types/minimatch": "*",
+            "@types/node": "*"
+          }
+        },
+        "ansi-align": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
+          "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "^3.0.0"
+          },
+          "dependencies": {
+            "emoji-regex": {
+              "version": "7.0.3",
+              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+              "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+              "dev": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true,
+              "optional": true
+            },
+            "string-width": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
+              }
+            }
+          }
+        },
+        "ansi-escapes": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
+          "integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "type-fest": "^0.5.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "any-observable": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.4.0.tgz",
+          "integrity": "sha512-63ve+0jP87qPo9Pgp52K0Hy1y4t1T5vcUoTQrOtZ5M2uC1dRI6fWaUbqKmf2tvrZEIbNVLZYbKyvQju3vCwJuA==",
+          "dev": true,
+          "optional": true
+        },
+        "boxen": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
+          "integrity": "sha512-cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-align": "^3.0.0",
+            "camelcase": "^5.3.1",
+            "chalk": "^2.4.2",
+            "cli-boxes": "^2.2.0",
+            "string-width": "^3.0.0",
+            "term-size": "^1.2.0",
+            "type-fest": "^0.3.0",
+            "widest-line": "^2.0.0"
+          },
+          "dependencies": {
+            "emoji-regex": {
+              "version": "7.0.3",
+              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+              "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+              "dev": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true,
+              "optional": true
+            },
+            "string-width": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
+              }
+            },
+            "type-fest": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+              "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true,
+          "optional": true
+        },
+        "ci-info": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+          "dev": true,
+          "optional": true
+        },
+        "cli-boxes": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
+          "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
+          "dev": true,
+          "optional": true
+        },
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "restore-cursor": "^3.1.0"
+          }
+        },
+        "configstore": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/configstore/-/configstore-4.0.0.tgz",
+          "integrity": "sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "dot-prop": "^4.1.0",
+            "graceful-fs": "^4.1.2",
+            "make-dir": "^1.0.0",
+            "unique-string": "^1.0.0",
+            "write-file-atomic": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
+          }
+        },
+        "cosmiconfig": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+          "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "import-fresh": "^2.0.0",
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.13.1",
+            "parse-json": "^4.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "del": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
+          "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@types/glob": "^7.1.1",
+            "globby": "^6.1.0",
+            "is-path-cwd": "^2.0.0",
+            "is-path-in-cwd": "^2.0.0",
+            "p-map": "^2.0.0",
+            "pify": "^4.0.1",
+            "rimraf": "^2.6.3"
+          }
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true,
+          "optional": true
+        },
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "dev": true,
+          "optional": true
+        },
+        "execa": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
+          "integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^3.0.0",
+            "onetime": "^5.1.0",
+            "p-finally": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "figures": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
+          "integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          },
+          "dependencies": {
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "got": {
+          "version": "9.6.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+          "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@sindresorhus/is": "^0.14.0",
+            "@szmarczak/http-timer": "^1.1.2",
+            "cacheable-request": "^6.0.0",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^4.1.0",
+            "lowercase-keys": "^1.0.1",
+            "mimic-response": "^1.0.1",
+            "p-cancelable": "^1.0.0",
+            "to-readable-stream": "^1.0.0",
+            "url-parse-lax": "^3.0.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+              "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "pump": "^3.0.0"
+              }
+            }
+          }
+        },
+        "hosted-git-info": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.2.tgz",
+          "integrity": "sha512-ezZMWtHXm7Eb7Rq4Mwnx2vs79WUx2QmRg3+ZqeGroKzfDO+EprOcgRPYghsOP9JuYBfK18VojmRTGCg8Ma+ktw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "lru-cache": "^5.1.1"
+          }
+        },
+        "inquirer": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.0.tgz",
+          "integrity": "sha512-rSdC7zelHdRQFkWnhsMu2+2SO41mpv2oF2zy4tMhmiLWkcKbOAs87fWAJhVXttKVwhdZvymvnuM95EyEXg2/tQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^2.4.2",
+            "cli-cursor": "^3.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^3.0.3",
+            "figures": "^3.0.0",
+            "lodash": "^4.17.15",
+            "mute-stream": "0.0.8",
+            "run-async": "^2.2.0",
+            "rxjs": "^6.4.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^5.1.0",
+            "through": "^2.3.6"
+          }
+        },
+        "is-ci": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+          "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ci-info": "^2.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true,
+          "optional": true
+        },
+        "is-installed-globally": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.2.0.tgz",
+          "integrity": "sha512-g3TzWCnR/eO4Q3abCwgFjOFw7uVOfxG4m8hMr/39Jcf2YvE5mHrFKqpyuraWV4zwx9XhjnVO4nY0ZI4llzl0Pg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "global-dirs": "^0.1.1",
+            "is-path-inside": "^2.1.0"
+          }
+        },
+        "is-npm": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-3.0.0.tgz",
+          "integrity": "sha512-wsigDr1Kkschp2opC4G3yA6r9EgVA6NjRpWzIi9axXqeIaAATPRJc4uLujXe3Nd9uO8KoDyA4MD6aZSeXTADhA==",
+          "dev": true,
+          "optional": true
+        },
+        "is-path-cwd": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+          "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+          "dev": true,
+          "optional": true
+        },
+        "is-path-in-cwd": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+          "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-path-inside": "^2.1.0"
+          }
+        },
+        "is-path-inside": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
+          "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
+          "dev": true,
+          "requires": {
+            "path-is-inside": "^1.0.2"
+          }
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true,
+          "optional": true
+        },
+        "latest-version": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
+          "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "package-json": "^6.3.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "log-symbols": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+          "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chalk": "^2.4.2"
+          }
+        },
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "merge-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+          "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+          "dev": true,
+          "optional": true
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+          "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+          "dev": true,
+          "optional": true
+        },
+        "npm-run-path": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
+          "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "p-finally": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+          "dev": true,
+          "optional": true
+        },
+        "p-limit": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-map": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+          "dev": true,
+          "optional": true
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "package-json": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
+          "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "got": "^9.6.0",
+            "registry-auth-token": "^4.0.0",
+            "registry-url": "^5.0.0",
+            "semver": "^6.2.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "path-key": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
+          "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
+          "dev": true
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true,
+          "optional": true
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        },
+        "prepend-http": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+          "dev": true,
+          "optional": true
+        },
+        "read-pkg": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
+          },
+          "dependencies": {
+            "parse-json": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+              "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1",
+                "lines-and-columns": "^1.1.6"
+              }
+            },
+            "type-fest": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+              "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "read-pkg-up": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-6.0.0.tgz",
+          "integrity": "sha512-odtTvLl+EXo1eTsMnoUHRmg/XmXdTkwXVxy4VFE9Kp6cCq7b3l7QMdBndND3eAFzrbSAXC/WCUOQQ9rLjifKZw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "find-up": "^4.0.0",
+            "read-pkg": "^5.1.1",
+            "type-fest": "^0.5.0"
+          }
+        },
+        "registry-auth-token": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.0.0.tgz",
+          "integrity": "sha512-lpQkHxd9UL6tb3k/aHAVfnVtn+Bcs9ob5InuFLLEDqSqeq+AljB8GZW9xY0x7F+xYwEcjKe07nyoxzEYz6yvkw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "rc": "^1.2.8",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "registry-url": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+          "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "rc": "^1.2.8"
+          }
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
+          "integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^5.2.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
+          "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
+          "dev": true
+        },
+        "update-notifier": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-3.0.1.tgz",
+          "integrity": "sha512-grrmrB6Zb8DUiyDIaeRTBCkgISYUgETNe7NglEbVsrLWXeESnlCSP50WfRSj/GmzMPl6Uchj24S/p80nP/ZQrQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "boxen": "^3.0.0",
+            "chalk": "^2.0.1",
+            "configstore": "^4.0.0",
+            "has-yarn": "^2.1.0",
+            "import-lazy": "^2.1.0",
+            "is-ci": "^2.0.0",
+            "is-installed-globally": "^0.1.0",
+            "is-npm": "^3.0.0",
+            "is-yarn-global": "^0.3.0",
+            "latest-version": "^5.0.0",
+            "semver-diff": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
+          },
+          "dependencies": {
+            "is-installed-globally": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+              "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "global-dirs": "^0.1.0",
+                "is-path-inside": "^1.0.0"
+              }
+            },
+            "is-path-inside": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+              "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "path-is-inside": "^1.0.1"
+              }
+            }
+          }
+        },
+        "url-parse-lax": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+          "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "prepend-http": "^2.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.1.tgz",
+          "integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "npm-name": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/npm-name/-/npm-name-5.5.0.tgz",
+      "integrity": "sha512-l7/uyVfEi2e3ho+ovaJZC0xlbwzXNUz3RxkxpfcnLuoGKAuYoo9YoJ/uy18PsTD8IziugGHks4t/mGmBJEZ4Qg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "got": "^9.6.0",
+        "is-scoped": "^2.1.0",
+        "is-url-superb": "^3.0.0",
+        "lodash.zip": "^4.2.0",
+        "registry-auth-token": "^4.0.0",
+        "registry-url": "^5.1.0",
+        "validate-npm-package-name": "^3.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "got": {
+          "version": "9.6.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+          "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@sindresorhus/is": "^0.14.0",
+            "@szmarczak/http-timer": "^1.1.2",
+            "cacheable-request": "^6.0.0",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^4.1.0",
+            "lowercase-keys": "^1.0.1",
+            "mimic-response": "^1.0.1",
+            "p-cancelable": "^1.0.0",
+            "to-readable-stream": "^1.0.0",
+            "url-parse-lax": "^3.0.0"
+          }
+        },
+        "prepend-http": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+          "dev": true,
+          "optional": true
+        },
+        "registry-auth-token": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.0.0.tgz",
+          "integrity": "sha512-lpQkHxd9UL6tb3k/aHAVfnVtn+Bcs9ob5InuFLLEDqSqeq+AljB8GZW9xY0x7F+xYwEcjKe07nyoxzEYz6yvkw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "rc": "^1.2.8",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "registry-url": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+          "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "rc": "^1.2.8"
+          }
+        },
+        "url-parse-lax": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+          "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "prepend-http": "^2.0.0"
+          }
+        }
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -15665,6 +17185,16 @@
         "mimic-fn": "^1.0.0"
       }
     },
+    "open": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
+      "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "is-wsl": "^1.1.0"
+      }
+    },
     "opencollective-postinstall": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
@@ -15794,6 +17324,31 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
+    "ow": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/ow/-/ow-0.13.2.tgz",
+      "integrity": "sha512-9wvr+q+ZTDRvXDjL6eDOdFe5WUl/wa5sntf9kAolxqSpkBqaIObwLgFCGXSJASFw+YciXnOVtDWpxXa9cqV94A==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "type-fest": "^0.5.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
+          "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "p-cancelable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+      "dev": true
+    },
     "p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
@@ -15839,11 +17394,52 @@
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
     },
+    "p-memoize": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-memoize/-/p-memoize-3.1.0.tgz",
+      "integrity": "sha512-e5tIvrsr7ydUUnxb534iQWtXxWgk/86IsH+H+nV4FHouIggBt4coXboKBt26o4lTu7JbEnGSeXdEsYR8BhAHFA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "mem": "^4.3.0",
+        "mimic-fn": "^2.1.0"
+      },
+      "dependencies": {
+        "mem": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+          "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "map-age-cleaner": "^0.1.1",
+            "mimic-fn": "^2.0.0",
+            "p-is-promise": "^2.0.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        }
+      }
+    },
     "p-reduce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
       "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
       "dev": true
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
     },
     "p-try": {
       "version": "1.0.0",
@@ -17904,6 +19500,13 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
       "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg=="
     },
+    "quick-lru": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+      "dev": true,
+      "optional": true
+    },
     "quote-stream": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz",
@@ -18418,6 +20021,26 @@
         }
       }
     },
+    "redent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+      "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "indent-string": "^3.0.0",
+        "strip-indent": "^2.0.0"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "redux": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
@@ -18828,6 +20451,15 @@
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
+    "responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "dev": true,
+      "requires": {
+        "lowercase-keys": "^1.0.0"
+      }
+    },
     "restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -19023,6 +20655,12 @@
         "ajv": "^6.1.0",
         "ajv-keywords": "^3.1.0"
       }
+    },
+    "scoped-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scoped-regex/-/scoped-regex-2.1.0.tgz",
+      "integrity": "sha512-g3WxHrqSWCZHGHlSrF51VXFdjImhwvH8ZO/pryFH56Qi0cDsZfylQa/t0jCzVQFNbNvM00HfHjkDPEuarKDSWQ==",
+      "dev": true
     },
     "scroll": {
       "version": "3.0.1",
@@ -19780,6 +21418,16 @@
         }
       }
     },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "through": "2"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -20152,6 +21800,13 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true
     },
+    "strip-indent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+      "dev": true,
+      "optional": true
+    },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -20212,6 +21867,35 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "supports-hyperlinks": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.0.0.tgz",
+      "integrity": "sha512-bFhn0MQ8qefLyJ3K7PpHiPUTuTVPWw6RXfaMeV6xgJLXtBbszyboz1bvGTVv4R0YpQm2DqlXXn0fFHhxUHVE5w==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "svg2png": {
@@ -20530,6 +22214,36 @@
         "execa": "^0.7.0"
       }
     },
+    "terminal-link": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.0.0.tgz",
+      "integrity": "sha512-rdBAY35jUvVapqCuhehjenLbYY73cVgRQ6podD6u9EDBomBBHjCOtmq2InPgPpTysOIOsQ5PdBzwSC/sKjv6ew==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "supports-hyperlinks": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
+          "integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "type-fest": "^0.5.2"
+          }
+        },
+        "type-fest": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
+          "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "terser": {
       "version": "3.16.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-3.16.1.tgz",
@@ -20792,6 +22506,13 @@
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
       "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
     },
+    "tlds": {
+      "version": "1.203.1",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.203.1.tgz",
+      "integrity": "sha512-7MUlYyGJ6rSitEZ3r1Q1QNV8uSIzapS8SmmhSusBuIc7uIxPPwsKllEP0GRp1NS6Ik6F+fRZvnjDWm3ecv2hDw==",
+      "dev": true,
+      "optional": true
+    },
     "tmp": {
       "version": "0.0.31",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
@@ -20862,6 +22583,12 @@
           }
         }
       }
+    },
+    "to-readable-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+      "dev": true
     },
     "to-regex": {
       "version": "3.0.2",
@@ -20941,6 +22668,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.1.tgz",
       "integrity": "sha512-X+eloHbgJGxczUk1WSjIvn7aC9oN3jVE3rQfRVKcgpavi3jxtCn0VVKtjOBj64Yop96UYn/ujJRpTbCdAF1vyg=="
+    },
+    "trim-newlines": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+      "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+      "dev": true,
+      "optional": true
     },
     "trim-right": {
       "version": "1.0.1",
@@ -21629,6 +23363,16 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "validate-npm-package-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "builtins": "^1.0.3"
       }
     },
     "vary": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3860,10 +3860,38 @@
         "glob-to-regexp": "^0.3.0"
       }
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.3",
+        "run-parallel": "^1.1.9"
+      },
+      "dependencies": {
+        "@nodelib/fs.stat": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+          "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+          "dev": true
+        }
+      }
+    },
     "@nodelib/fs.stat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.3",
+        "fastq": "^1.6.0"
+      }
     },
     "@parcel/fs": {
       "version": "1.11.0",
@@ -3976,6 +4004,15 @@
         "prop-types": "^15.6.1",
         "react-lifecycles-compat": "^3.0.4",
         "warning": "^3.0.0"
+      }
+    },
+    "@samverschueren/stream-to-observable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
+      "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
+      "dev": true,
+      "requires": {
+        "any-observable": "^0.3.0"
       }
     },
     "@types/babel__core": {
@@ -4106,6 +4143,12 @@
       "version": "7.10.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.3.tgz",
       "integrity": "sha512-HeyK+csRk7Khhg9krpMGJeT9pLzjsmiJFHYRzYpPv/dQ5tPclQsbvceiX/HKynRt/9lMLorWUYTbBHC3hRI4sg=="
+    },
+    "@types/normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
     },
     "@types/prop-types": {
       "version": "15.5.9",
@@ -4391,6 +4434,16 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
     },
+    "aggregate-error": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      }
+    },
     "ajv": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
@@ -4466,6 +4519,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
       "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="
+    },
+    "any-observable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
+      "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
+      "dev": true
     },
     "anymatch": {
       "version": "2.0.0",
@@ -5824,6 +5883,12 @@
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
       "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true
+    },
     "cli-boxes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
@@ -5851,6 +5916,35 @@
         "colors": "^1.1.2",
         "object-assign": "^4.1.0",
         "string-width": "^2.1.1"
+      }
+    },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "^1.0.1"
+      },
+      "dependencies": {
+        "slice-ansi": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        }
       }
     },
     "cli-width": {
@@ -6855,6 +6949,12 @@
         }
       }
     },
+    "date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+      "dev": true
+    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
@@ -6895,6 +6995,12 @@
       "requires": {
         "mimic-response": "^1.0.0"
       }
+    },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
     },
     "deep-diff": {
       "version": "1.0.2",
@@ -7195,6 +7301,23 @@
         "randombytes": "^2.0.0"
       }
     },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      },
+      "dependencies": {
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+          "dev": true
+        }
+      }
+    },
     "dns-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
@@ -7374,6 +7497,12 @@
       "version": "1.3.113",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz",
       "integrity": "sha512-De+lPAxEcpxvqPTyZAXELNpRZXABRxf+uL/rSykstQhzj/B0l1150G/ExIIxKc16lI89Hgz81J0BHAcbTqK49g=="
+    },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+      "dev": true
     },
     "elliptic": {
       "version": "6.4.1",
@@ -8597,6 +8726,15 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
       "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ=="
+    },
+    "fastq": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
+      "integrity": "sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.0"
+      }
     },
     "favicons": {
       "version": "5.3.0",
@@ -11106,6 +11244,188 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
+    "husky": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-3.0.9.tgz",
+      "integrity": "sha512-Yolhupm7le2/MqC1VYLk/cNmYxsSsqKkTyBhzQHhPK1jFnC89mmmNVuGtLNabjDI6Aj8UNIr0KpRNuBkiC4+sg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "ci-info": "^2.0.0",
+        "cosmiconfig": "^5.2.1",
+        "execa": "^1.0.0",
+        "get-stdin": "^7.0.0",
+        "opencollective-postinstall": "^2.0.2",
+        "pkg-dir": "^4.2.0",
+        "please-upgrade-node": "^3.2.0",
+        "read-pkg": "^5.2.0",
+        "run-node": "^1.0.0",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "ci-info": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+          "dev": true
+        },
+        "cosmiconfig": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+          "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+          "dev": true,
+          "requires": {
+            "import-fresh": "^2.0.0",
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.13.1",
+            "parse-json": "^4.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "get-stdin": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+          "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
+          },
+          "dependencies": {
+            "parse-json": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+              "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+              "dev": true,
+              "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1",
+                "lines-and-columns": "^1.1.6"
+              }
+            }
+          }
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -11694,6 +12014,12 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true
+    },
     "indexes-of": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
@@ -12038,6 +12364,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+    },
+    "is-observable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
+      "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "^1.1.0"
+      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -13533,6 +13868,493 @@
         "immediate": "~3.0.5"
       }
     },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
+    "lint-staged": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-9.4.2.tgz",
+      "integrity": "sha512-OFyGokJSWTn2M6vngnlLXjaHhi8n83VIZZ5/1Z26SULRUWgR3ITWpAEQC9Pnm3MC/EpCxlwts/mQWDHNji2+zA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "commander": "^2.20.0",
+        "cosmiconfig": "^5.2.1",
+        "debug": "^4.1.1",
+        "dedent": "^0.7.0",
+        "del": "^5.0.0",
+        "execa": "^2.0.3",
+        "listr": "^0.14.3",
+        "log-symbols": "^3.0.0",
+        "micromatch": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "please-upgrade-node": "^3.1.1",
+        "string-argv": "^0.3.0",
+        "stringify-object": "^3.3.0"
+      },
+      "dependencies": {
+        "@nodelib/fs.stat": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+          "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+          "dev": true
+        },
+        "@types/glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+          "dev": true,
+          "requires": {
+            "@types/events": "*",
+            "@types/minimatch": "*",
+            "@types/node": "*"
+          }
+        },
+        "array-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+          "dev": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        },
+        "cosmiconfig": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+          "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+          "dev": true,
+          "requires": {
+            "import-fresh": "^2.0.0",
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.13.1",
+            "parse-json": "^4.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "del": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/del/-/del-5.1.0.tgz",
+          "integrity": "sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==",
+          "dev": true,
+          "requires": {
+            "globby": "^10.0.1",
+            "graceful-fs": "^4.2.2",
+            "is-glob": "^4.0.1",
+            "is-path-cwd": "^2.2.0",
+            "is-path-inside": "^3.0.1",
+            "p-map": "^3.0.0",
+            "rimraf": "^3.0.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "execa": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
+          "integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^3.0.0",
+            "onetime": "^5.1.0",
+            "p-finally": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "fast-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.0.tgz",
+          "integrity": "sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.0",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.2"
+          },
+          "dependencies": {
+            "merge2": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+              "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+              "dev": true
+            }
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+          "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "globby": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
+          "integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
+          "dev": true,
+          "requires": {
+            "@types/glob": "^7.1.1",
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.0.3",
+            "glob": "^7.1.3",
+            "ignore": "^5.1.1",
+            "merge2": "^1.2.3",
+            "slash": "^3.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+          "dev": true
+        },
+        "ignore": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "is-path-cwd": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+          "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+          "dev": true
+        },
+        "is-path-inside": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
+          "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+          "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2"
+          }
+        },
+        "merge-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+          "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
+          "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "p-finally": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+          "dev": true
+        },
+        "p-map": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+          "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+          "dev": true,
+          "requires": {
+            "aggregate-error": "^3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
+          "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
+          "integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.1.tgz",
+          "integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "listr": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
+      "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
+      "dev": true,
+      "requires": {
+        "@samverschueren/stream-to-observable": "^0.3.0",
+        "is-observable": "^1.1.0",
+        "is-promise": "^2.1.0",
+        "is-stream": "^1.1.0",
+        "listr-silent-renderer": "^1.1.1",
+        "listr-update-renderer": "^0.5.0",
+        "listr-verbose-renderer": "^0.5.0",
+        "p-map": "^2.0.0",
+        "rxjs": "^6.3.3"
+      },
+      "dependencies": {
+        "p-map": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+          "dev": true
+        }
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true
+    },
+    "listr-update-renderer": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
+      "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "elegant-spinner": "^1.0.1",
+        "figures": "^1.7.0",
+        "indent-string": "^3.0.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^2.3.0",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
+      "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "cli-cursor": "^2.1.0",
+        "date-fns": "^1.27.2",
+        "figures": "^2.0.0"
+      }
+    },
     "load-bmfont": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.0.tgz",
@@ -13790,6 +14612,44 @@
       "dev": true,
       "requires": {
         "chalk": "^2.0.1"
+      }
+    },
+    "log-update": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
+      "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.0.0",
+        "cli-cursor": "^2.0.0",
+        "wrap-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+          "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0"
+          }
+        }
       }
     },
     "loglevel": {
@@ -14804,6 +15664,12 @@
       "requires": {
         "mimic-fn": "^1.0.0"
       }
+    },
+    "opencollective-postinstall": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
+      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
+      "dev": true
     },
     "opentracing": {
       "version": "0.14.3",
@@ -16090,6 +16956,15 @@
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
           "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
         }
+      }
+    },
+    "please-upgrade-node": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+      "dev": true,
+      "requires": {
+        "semver-compare": "^1.0.0"
       }
     },
     "pn": {
@@ -17976,6 +18851,12 @@
         "unherit": "^1.0.4"
       }
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
     "rgb-regex": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
@@ -18034,6 +18915,18 @@
       "requires": {
         "is-promise": "^2.1.0"
       }
+    },
+    "run-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/run-node/-/run-node-1.0.0.tgz",
+      "integrity": "sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==",
+      "dev": true
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "dev": true
     },
     "run-queue": {
       "version": "1.0.3",
@@ -18197,6 +19090,12 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
       "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -19084,6 +19983,12 @@
         "stream-to": "~0.2.0"
       }
     },
+    "string-argv": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+      "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
+      "dev": true
+    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -19240,6 +20145,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -20076,6 +20987,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -358,6 +358,16 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-proposal-dynamic-import": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.5.0.tgz",
+      "integrity": "sha512-x/iMjggsKTFHYC6g11PL7Qy58IK8H5zqfm9e6hu4z1iH2IRyAp9u9dL80zA6R76yFovETFLKz2VJIC2iIPBuFw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.2.0"
+      }
+    },
     "@babel/plugin-proposal-json-strings": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
@@ -735,6 +745,15 @@
       "integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
       "requires": {
         "regenerator-transform": "^0.13.3"
+      }
+    },
+    "@babel/plugin-transform-reserved-words": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz",
+      "integrity": "sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-runtime": {
@@ -3858,9 +3877,9 @@
       }
     },
     "@parcel/logger": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-1.11.0.tgz",
-      "integrity": "sha512-lIRfDg+junbFUUeU0QtHX00gKCgEsYHZydFKwrJ8dc0D+WE2SYT1FcVCgpPAfKYgtg0QQMns8E9vzT9UjH92PQ==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-1.11.1.tgz",
+      "integrity": "sha512-9NF3M6UVeP2udOBDILuoEHd8VrF4vQqoWHEafymO1pfSoOMfxrSJZw1MfyAAIUN/IFp9qjcpDCUbDZB+ioVevA==",
       "dev": true,
       "requires": {
         "@parcel/workers": "^1.11.0",
@@ -3894,13 +3913,47 @@
       "dev": true
     },
     "@parcel/watcher": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-1.12.0.tgz",
-      "integrity": "sha512-yijGiAqG7Tjf5WnFwOkiNWwerfZQDNABldiiqRDtr7vDWLO+F/DIncyB7tTcaD5Loevrr5mzzGo8Ntf3d2GIPg==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-1.12.1.tgz",
+      "integrity": "sha512-od+uCtCxC/KoNQAIE1vWx1YTyKYY+7CTrxBJPRh3cDWw/C0tCtlBMVlrbplscGoEpt6B27KhJDCv82PBxOERNA==",
       "dev": true,
       "requires": {
         "@parcel/utils": "^1.11.0",
-        "chokidar": "^2.0.3"
+        "chokidar": "^2.1.5"
+      },
+      "dependencies": {
+        "chokidar": {
+          "version": "2.1.8",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+          "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+          "dev": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.1"
+          }
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true
+        },
+        "upath": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+          "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+          "dev": true
+        }
       }
     },
     "@parcel/workers": {
@@ -4278,12 +4331,6 @@
       "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
       "dev": true
     },
-    "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
-    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -4324,9 +4371,9 @@
       }
     },
     "acorn-jsx": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
-      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+      "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw=="
     },
     "acorn-walk": {
       "version": "6.1.1",
@@ -4407,12 +4454,12 @@
       }
     },
     "ansi-to-html": {
-      "version": "0.6.11",
-      "resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.6.11.tgz",
-      "integrity": "sha512-88XZtrcwrfkyn6fGstHnkaF1kl7hGtNCYh4vSmItgEV+6JnQHryDBf7udF4f2RhTRQmYvJvPcTtqgaqrxzc9oA==",
+      "version": "0.6.12",
+      "resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.6.12.tgz",
+      "integrity": "sha512-qBkIqLW979675mP76yB7yVkzeAWtATegdnDQ0RA3CZzknx0yUlNxMSML4xFdBfTs2GWYFQ1FELfbGbVSPzJ+LA==",
       "dev": true,
       "requires": {
-        "entities": "^1.1.1"
+        "entities": "^1.1.2"
       }
     },
     "any-base": {
@@ -4714,16 +4761,28 @@
       "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg=="
     },
     "babel-eslint": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-9.0.0.tgz",
-      "integrity": "sha512-itv1MwE3TMbY0QtNfeL7wzak1mV47Uy+n6HtSOO4Xd7rvmO+tsGQSgyOEEgo6Y2vHZKZphaoelNeSVj4vkLA1g==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.3.tgz",
+      "integrity": "sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/parser": "^7.0.0",
         "@babel/traverse": "^7.0.0",
         "@babel/types": "^7.0.0",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "^1.0.0"
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+          "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
       }
     },
     "babel-extract-comments": {
@@ -5857,12 +5916,6 @@
         "readable-stream": "^2.3.5"
       }
     },
-    "clones": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/clones/-/clones-1.2.0.tgz",
-      "integrity": "sha512-FXDYw4TjR8wgPZYui2LeTqWh1BLpfQ8lB6upMtlpDF6WlOOxghmTTxWyngdKTgozqBgKnHbTVwTE+hOHqAykuQ==",
-      "dev": true
-    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6043,16 +6096,6 @@
         "typedarray": "^0.0.6"
       }
     },
-    "config-chain": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
-      "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
-      "dev": true,
-      "requires": {
-        "ini": "^1.3.4",
-        "proto-list": "~1.2.1"
-      }
-    },
     "configstore": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
@@ -6167,6 +6210,56 @@
       "version": "2.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
       "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+    },
+    "core-js-compat": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.3.2.tgz",
+      "integrity": "sha512-gfiK4QnNXhnnHVOIZst2XHdFfdMTPxtR0EGs0TdILMlGIft+087oH6/Sw2xTTIjpWXC9vEwsJA8VG3XTGcmO5g==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.7.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "4.7.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.0.tgz",
+          "integrity": "sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30000989",
+            "electron-to-chromium": "^1.3.247",
+            "node-releases": "^1.1.29"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000999",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000999.tgz",
+          "integrity": "sha512-1CUyKyecPeksKwXZvYw0tEoaMCo/RwBlXmEtN5vVnabvO0KPd9RQLcaAuR9/1F+KDMv6esmOFWlsXuzDk+8rxg==",
+          "dev": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.282",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.282.tgz",
+          "integrity": "sha512-irSaDeCGgfMu1OA30bhqIBr+dx+pDJjRbwCpob7YWqVZbzXblybNzPGklVnWqv4EXxbkEAzQYqiNCqNTgu00lQ==",
+          "dev": true
+        },
+        "node-releases": {
+          "version": "1.1.36",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.36.tgz",
+          "integrity": "sha512-ggXhX6QGyJSjj3r+6ml2LqqC28XOWmKtpb+a15/Zpr9V3yoNazxJNlcQDS9bYaid5FReEWHEgToH1mwoUceWwg==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.3.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -6726,9 +6819,9 @@
       }
     },
     "damerau-levenshtein": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
-      "integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
+      "integrity": "sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA=="
     },
     "dashdash": {
       "version": "1.14.1",
@@ -7228,9 +7321,9 @@
       "dev": true
     },
     "dotenv-expand": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-4.2.0.tgz",
-      "integrity": "sha1-3vHxyl1gWdJKdm5YeULCEQbOEnU=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
       "dev": true
     },
     "duplexer": {
@@ -7270,18 +7363,6 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
-      }
-    },
-    "editorconfig": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
-      "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
-      "dev": true,
-      "requires": {
-        "commander": "^2.19.0",
-        "lru-cache": "^4.1.5",
-        "semver": "^5.6.0",
-        "sigmund": "^1.0.1"
       }
     },
     "ee-first": {
@@ -7589,104 +7670,231 @@
       }
     },
     "eslint": {
-      "version": "5.14.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.14.1.tgz",
-      "integrity": "sha512-CyUMbmsjxedx8B0mr79mNOqetvkbij/zrXnFeK2zc3pGRn3/tibjiNAv/3UxFEyfMDjh+ZqTrJrEGBFiGfD5Og==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.5.1.tgz",
+      "integrity": "sha512-32h99BoLYStT1iq1v2P9uwpyznQ4M2jRiFB6acitKz52Gqn+vPaMDUTB1bYi1WN4Nquj2w+t+bimYUG83DC55A==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "ajv": "^6.9.1",
+        "ajv": "^6.10.0",
         "chalk": "^2.1.0",
         "cross-spawn": "^6.0.5",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
-        "eslint-scope": "^4.0.0",
-        "eslint-utils": "^1.3.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^5.0.1",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^1.4.2",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.1",
         "esquery": "^1.0.1",
         "esutils": "^2.0.2",
         "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob": "^7.1.2",
+        "glob-parent": "^5.0.0",
         "globals": "^11.7.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^6.2.2",
-        "js-yaml": "^3.12.0",
+        "inquirer": "^6.4.1",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.14",
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
         "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.2",
         "progress": "^2.0.0",
         "regexpp": "^2.0.1",
-        "semver": "^5.5.1",
-        "strip-ansi": "^4.0.0",
-        "strip-json-comments": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
         "table": "^5.2.3",
-        "text-table": "^0.2.0"
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
         },
         "cross-spawn": {
           "version": "6.0.5",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
           "requires": {
             "nice-try": "^1.0.4",
             "path-key": "^2.0.1",
             "semver": "^5.5.0",
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true
+            }
           }
         },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "eslint-scope": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-          "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+          "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+          "dev": true,
           "requires": {
             "esrecurse": "^4.1.0",
             "estraverse": "^4.1.1"
           }
         },
+        "eslint-visitor-keys": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+          "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+          "dev": true
+        },
+        "glob-parent": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+          "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+              "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.1"
+              }
+            }
+          }
+        },
         "import-fresh": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
-          "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
+          "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
+          "dev": true,
           "requires": {
             "parent-module": "^1.0.0",
             "resolve-from": "^4.0.0"
           }
         },
+        "inquirer": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+          "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.2.0",
+            "chalk": "^2.4.2",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^3.0.3",
+            "figures": "^2.0.0",
+            "lodash": "^4.17.12",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rxjs": "^6.4.0",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^5.1.0",
+            "through": "^2.3.6"
+          }
+        },
         "resolve-from": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^4.1.0"
           }
+        },
+        "strip-json-comments": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+          "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+          "dev": true
         }
+      }
+    },
+    "eslint-config-airbnb": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.0.1.tgz",
+      "integrity": "sha512-hLb/ccvW4grVhvd6CT83bECacc+s4Z3/AEyWQdIT2KeTsG9dR7nx1gs7Iw4tDmGKozCNHFn4yZmRm3Tgy+XxyQ==",
+      "dev": true,
+      "requires": {
+        "eslint-config-airbnb-base": "^14.0.0",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.1.0"
+      }
+    },
+    "eslint-config-airbnb-base": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.0.0.tgz",
+      "integrity": "sha512-2IDHobw97upExLmsebhtfoD3NAKhV4H0CJWP3Uprd/uk+cHuWYOczPVxQ8PxLFUAw7o3Th1RAU8u1DoUpr+cMA==",
+      "dev": true,
+      "requires": {
+        "confusing-browser-globals": "^1.0.7",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.1.0"
+      },
+      "dependencies": {
+        "confusing-browser-globals": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz",
+          "integrity": "sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-config-prettier": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.4.0.tgz",
+      "integrity": "sha512-YrKucoFdc7SEko5Sxe4r6ixqXPDP1tunGw91POeZTTRKItf/AMFYt/YLEQtZMkR2LVpAVhcAcZgcWpm1oGPW7w==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
       }
     },
     "eslint-config-react-app": {
@@ -7734,9 +7942,9 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz",
-      "integrity": "sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
+      "integrity": "sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==",
       "requires": {
         "debug": "^2.6.8",
         "pkg-dir": "^2.0.0"
@@ -7783,20 +7991,21 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.16.0.tgz",
-      "integrity": "sha512-z6oqWlf1x5GkHIFgrSvtmudnqM6Q60KM4KvpWi5ubonMjycLjndvd5+8VAZIsTlHC03djdgJuyKG6XO577px6A==",
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
+      "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
       "requires": {
+        "array-includes": "^3.0.3",
         "contains-path": "^0.1.0",
         "debug": "^2.6.9",
         "doctrine": "1.5.0",
         "eslint-import-resolver-node": "^0.3.2",
-        "eslint-module-utils": "^2.3.0",
+        "eslint-module-utils": "^2.4.0",
         "has": "^1.0.3",
-        "lodash": "^4.17.11",
         "minimatch": "^3.0.4",
+        "object.values": "^1.1.0",
         "read-pkg-up": "^2.0.0",
-        "resolve": "^1.9.0"
+        "resolve": "^1.11.0"
       },
       "dependencies": {
         "debug": {
@@ -7820,14 +8029,23 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "resolve": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+          "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
         }
       }
     },
     "eslint-plugin-jsx-a11y": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.1.tgz",
-      "integrity": "sha512-cjN2ObWrRz0TTw7vEcGQrx+YltMvZoOEx4hWU8eEERDnBIU00OTq7Vr+jA7DFKxiwLNv4tTh5Pq2GUNEa8b6+w==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz",
+      "integrity": "sha512-CawzfGt9w83tyuVekn0GDPU9ytYtxyxyFZ3aSWROmnRRFQFT2BiPJd7jvRdzNDi6oLWaS2asMeYSNMjWTV4eNg==",
       "requires": {
+        "@babel/runtime": "^7.4.5",
         "aria-query": "^3.0.0",
         "array-includes": "^3.0.3",
         "ast-types-flow": "^0.0.7",
@@ -7835,21 +8053,47 @@
         "damerau-levenshtein": "^1.0.4",
         "emoji-regex": "^7.0.2",
         "has": "^1.0.3",
-        "jsx-ast-utils": "^2.0.1"
+        "jsx-ast-utils": "^2.2.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
+          "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.1.tgz",
+      "integrity": "sha512-A+TZuHZ0KU0cnn56/9mfR7/KjUJ9QNVXUhwvRFSR7PGPe0zQR6PTkmyqg1AtUUEOzTqeRsUwyKFh0oVZKVCrtA==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-plugin-react": {
-      "version": "7.12.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz",
-      "integrity": "sha512-1puHJkXJY+oS1t467MjbqjvX53uQ05HXwjqDgdbGBqf5j9eeydI54G3KwiJmWciQ0HTBacIKw2jgwSBSH3yfgQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.16.0.tgz",
+      "integrity": "sha512-GacBAATewhhptbK3/vTP09CbFrgUJmBSaaRcWdbQLFvUZy9yVcQxigBNHGPU/KE2AyHpzj3AWXpxoMTsIDiHug==",
       "requires": {
         "array-includes": "^3.0.3",
         "doctrine": "^2.1.0",
         "has": "^1.0.3",
-        "jsx-ast-utils": "^2.0.1",
+        "jsx-ast-utils": "^2.2.1",
+        "object.entries": "^1.1.0",
         "object.fromentries": "^2.0.0",
-        "prop-types": "^15.6.2",
-        "resolve": "^1.9.0"
+        "object.values": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "resolve": "^1.12.0"
       },
       "dependencies": {
         "doctrine": {
@@ -7859,16 +8103,33 @@
           "requires": {
             "esutils": "^2.0.2"
           }
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "resolve": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+          "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
         }
-      }
-    },
-    "eslint-scope": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-      "requires": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
       }
     },
     "eslint-utils": {
@@ -7885,13 +8146,28 @@
       "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
     },
     "espree": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
-      "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
+      "integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+      "dev": true,
       "requires": {
-        "acorn": "^6.0.7",
-        "acorn-jsx": "^5.0.0",
-        "eslint-visitor-keys": "^1.0.0"
+        "acorn": "^7.0.0",
+        "acorn-jsx": "^5.0.2",
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+          "dev": true
+        },
+        "eslint-visitor-keys": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+          "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+          "dev": true
+        }
       }
     },
     "esprima": {
@@ -8288,6 +8564,12 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
+    },
     "fast-glob": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.6.tgz",
@@ -8554,9 +8836,9 @@
       }
     },
     "flatted": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
-      "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg=="
     },
     "flush-write-stream": {
       "version": "1.1.1",
@@ -8736,8 +9018,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8755,13 +9036,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8774,18 +9053,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8888,8 +9164,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8899,7 +9174,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8912,20 +9186,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8942,7 +9213,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9015,8 +9285,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9026,7 +9295,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9102,8 +9370,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9133,7 +9400,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9151,7 +9417,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9190,13 +9455,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -9365,6 +9628,30 @@
             }
           }
         },
+        "babel-eslint": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-9.0.0.tgz",
+          "integrity": "sha512-itv1MwE3TMbY0QtNfeL7wzak1mV47Uy+n6HtSOO4Xd7rvmO+tsGQSgyOEEgo6Y2vHZKZphaoelNeSVj4vkLA1g==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.0.0",
+            "@babel/traverse": "^7.0.0",
+            "@babel/types": "^7.0.0",
+            "eslint-scope": "3.7.1",
+            "eslint-visitor-keys": "^1.0.0"
+          },
+          "dependencies": {
+            "eslint-scope": {
+              "version": "3.7.1",
+              "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+              "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+              "requires": {
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
+              }
+            }
+          }
+        },
         "cliui": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
@@ -9379,6 +9666,90 @@
           "version": "4.0.0",
           "resolved": "http://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
           "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
+        },
+        "eslint": {
+          "version": "5.16.0",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
+          "integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "ajv": "^6.9.1",
+            "chalk": "^2.1.0",
+            "cross-spawn": "^6.0.5",
+            "debug": "^4.0.1",
+            "doctrine": "^3.0.0",
+            "eslint-scope": "^4.0.3",
+            "eslint-utils": "^1.3.1",
+            "eslint-visitor-keys": "^1.0.0",
+            "espree": "^5.0.1",
+            "esquery": "^1.0.1",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^5.0.1",
+            "functional-red-black-tree": "^1.0.1",
+            "glob": "^7.1.2",
+            "globals": "^11.7.0",
+            "ignore": "^4.0.6",
+            "import-fresh": "^3.0.0",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^6.2.2",
+            "js-yaml": "^3.13.0",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.11",
+            "minimatch": "^3.0.4",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "path-is-inside": "^1.0.2",
+            "progress": "^2.0.0",
+            "regexpp": "^2.0.1",
+            "semver": "^5.5.1",
+            "strip-ansi": "^4.0.0",
+            "strip-json-comments": "^2.0.1",
+            "table": "^5.2.3",
+            "text-table": "^0.2.0"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "6.0.5",
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+              "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+              "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
+            "debug": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            }
+          }
+        },
+        "eslint-scope": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+          "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "espree": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+          "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+          "requires": {
+            "acorn": "^6.0.7",
+            "acorn-jsx": "^5.0.0",
+            "eslint-visitor-keys": "^1.0.0"
+          }
         },
         "execa": {
           "version": "0.8.0",
@@ -9432,6 +9803,20 @@
               }
             }
           }
+        },
+        "import-fresh": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
+          "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
         },
         "strip-ansi": {
           "version": "4.0.0",
@@ -9822,6 +10207,12 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
       "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
+    },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+      "dev": true
     },
     "get-stream": {
       "version": "3.0.0",
@@ -10530,9 +10921,9 @@
       },
       "dependencies": {
         "commander": {
-          "version": "2.20.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
-          "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==",
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true
         },
         "css-select": {
@@ -10613,9 +11004,9 @@
           }
         },
         "terser": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-4.3.4.tgz",
-          "integrity": "sha512-Kcrn3RiW8NtHBP0ssOAzwa2MsIRQ8lJWiBG/K7JgqPlomA3mtb2DEmp4/hrUA+Jujx+WZ02zqd7GYD+QRBB/2Q==",
+          "version": "4.3.9",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.3.9.tgz",
+          "integrity": "sha512-NFGMpHjlzmyOtPL+fDw3G7+6Ueh/sz4mkaUYa4lJCxOPTNzd0Uj0aZJOmsDYoSQyfuVoWDMSWTPU3huyOm2zdA==",
           "dev": true,
           "requires": {
             "commander": "^2.20.0",
@@ -10770,8 +11161,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10789,13 +11179,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10808,18 +11196,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10922,8 +11307,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -10933,7 +11317,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10946,20 +11329,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -10976,7 +11356,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -11049,8 +11428,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -11060,7 +11438,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -11136,8 +11513,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -11167,7 +11543,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -11185,7 +11560,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -11224,13 +11598,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -12872,19 +13244,6 @@
       "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.4.tgz",
       "integrity": "sha512-6IzjQxvnlT8UlklNmDXIJMWxijULjqGrzgqc0OG7YadZdvm7KPQ1j0ehmQQHckgEWOfgpptzcnWgESovxudpTA=="
     },
-    "js-beautify": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.10.2.tgz",
-      "integrity": "sha512-ZtBYyNUYJIsBWERnQP0rPN9KjkrDfJcMjuVGcvXOUJrD1zmOGwhRwQ4msG+HJ+Ni/FA7+sRQEMYVzdTQDvnzvQ==",
-      "dev": true,
-      "requires": {
-        "config-chain": "^1.1.12",
-        "editorconfig": "^0.15.3",
-        "glob": "^7.1.3",
-        "mkdirp": "~0.5.1",
-        "nopt": "~4.0.1"
-      }
-    },
     "js-levenshtein": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
@@ -13065,11 +13424,12 @@
       }
     },
     "jsx-ast-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
-      "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
+      "integrity": "sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==",
       "requires": {
-        "array-includes": "^3.0.3"
+        "array-includes": "^3.0.3",
+        "object.assign": "^4.1.0"
       }
     },
     "jszip": {
@@ -14156,16 +14516,6 @@
       "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
       "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
     },
-    "nopt": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1",
-        "osenv": "^0.1.4"
-      }
-    },
     "normalize-html-whitespace": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/normalize-html-whitespace/-/normalize-html-whitespace-1.0.0.tgz",
@@ -14326,15 +14676,66 @@
         "isobject": "^3.0.0"
       }
     },
-    "object.fromentries": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
-      "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "requires": {
         "define-properties": "^1.1.2",
-        "es-abstract": "^1.11.0",
         "function-bind": "^1.1.1",
-        "has": "^1.0.1"
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.entries": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.1.tgz",
+      "integrity": "sha512-PUQv8Hbg3j2QX0IQYv3iAGCbGcu4yY4KQ92/dhA4sFSixBmSmp13UpDLs6jGK8rBtbmhNNIK99LD2k293jpiGA==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.15.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
+          "integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
+          "requires": {
+            "es-to-primitive": "^1.2.0",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.0",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.6.0",
+            "object-keys": "^1.1.1",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        },
+        "object-inspect": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+          "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+        }
       }
     },
     "object.getownpropertydescriptors": {
@@ -14527,16 +14928,6 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
-    "osenv": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "dev": true,
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
-      }
-    },
     "p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
@@ -14620,28 +15011,28 @@
       }
     },
     "parcel-bundler": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/parcel-bundler/-/parcel-bundler-1.12.3.tgz",
-      "integrity": "sha512-8bq6lj0hhQeGxD9f9xEkFMXQ3d8TIlf2+isKxoi9bciB0KVEILRGllaPkUgp++5t0anToBh9+tG6ZyInXOC1/A==",
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/parcel-bundler/-/parcel-bundler-1.12.4.tgz",
+      "integrity": "sha512-G+iZGGiPEXcRzw0fiRxWYCKxdt/F7l9a0xkiU4XbcVRJCSlBnioWEwJMutOCCpoQmaQtjB4RBHDGIHN85AIhLQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0 <7.4.0",
-        "@babel/core": "^7.0.0 <7.4.0",
-        "@babel/generator": "^7.0.0 <7.4.0",
-        "@babel/parser": "^7.0.0 <7.4.0",
-        "@babel/plugin-transform-flow-strip-types": "^7.0.0 <7.4.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.0.0 <7.4.0",
-        "@babel/plugin-transform-react-jsx": "^7.0.0 <7.4.0",
-        "@babel/preset-env": "^7.0.0 <7.4.0",
-        "@babel/runtime": "^7.0.0 <7.4.0",
-        "@babel/template": "^7.0.0 <7.4.0",
-        "@babel/traverse": "^7.0.0 <7.4.0",
-        "@babel/types": "^7.0.0 <7.4.0",
+        "@babel/code-frame": "^7.0.0",
+        "@babel/core": "^7.4.4",
+        "@babel/generator": "^7.4.4",
+        "@babel/parser": "^7.4.4",
+        "@babel/plugin-transform-flow-strip-types": "^7.4.4",
+        "@babel/plugin-transform-modules-commonjs": "^7.4.4",
+        "@babel/plugin-transform-react-jsx": "^7.0.0",
+        "@babel/preset-env": "^7.4.4",
+        "@babel/runtime": "^7.4.4",
+        "@babel/template": "^7.4.4",
+        "@babel/traverse": "^7.4.4",
+        "@babel/types": "^7.4.4",
         "@iarna/toml": "^2.2.0",
         "@parcel/fs": "^1.11.0",
-        "@parcel/logger": "^1.11.0",
+        "@parcel/logger": "^1.11.1",
         "@parcel/utils": "^1.11.0",
-        "@parcel/watcher": "^1.12.0",
+        "@parcel/watcher": "^1.12.1",
         "@parcel/workers": "^1.11.0",
         "ansi-to-html": "^0.6.4",
         "babylon-walk": "^1.0.2",
@@ -14650,12 +15041,14 @@
         "clone": "^2.1.1",
         "command-exists": "^1.2.6",
         "commander": "^2.11.0",
+        "core-js": "^2.6.5",
         "cross-spawn": "^6.0.4",
         "css-modules-loader-core": "^1.1.0",
         "cssnano": "^4.0.0",
         "deasync": "^0.1.14",
         "dotenv": "^5.0.0",
-        "dotenv-expand": "^4.2.0",
+        "dotenv-expand": "^5.1.0",
+        "envinfo": "^7.3.1",
         "fast-glob": "^2.2.2",
         "filesize": "^3.6.0",
         "get-port": "^3.2.0",
@@ -14676,7 +15069,7 @@
         "posthtml-render": "^1.1.3",
         "resolve": "^1.4.0",
         "semver": "^5.4.1",
-        "serialize-to-js": "^1.1.1",
+        "serialize-to-js": "^3.0.0",
         "serve-static": "^1.12.4",
         "source-map": "0.6.1",
         "terser": "^3.7.3",
@@ -14684,6 +15077,538 @@
         "ws": "^5.1.1"
       },
       "dependencies": {
+        "@babel/core": {
+          "version": "7.6.4",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.4.tgz",
+          "integrity": "sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.5.5",
+            "@babel/generator": "^7.6.4",
+            "@babel/helpers": "^7.6.2",
+            "@babel/parser": "^7.6.4",
+            "@babel/template": "^7.6.0",
+            "@babel/traverse": "^7.6.3",
+            "@babel/types": "^7.6.3",
+            "convert-source-map": "^1.1.0",
+            "debug": "^4.1.0",
+            "json5": "^2.1.0",
+            "lodash": "^4.17.13",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.5.5",
+              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+              "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+              "dev": true,
+              "requires": {
+                "@babel/highlight": "^7.0.0"
+              }
+            },
+            "json5": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+              "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+              "dev": true,
+              "requires": {
+                "minimist": "^1.2.0"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
+            }
+          }
+        },
+        "@babel/generator": {
+          "version": "7.6.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
+          "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.6.3",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
+            }
+          }
+        },
+        "@babel/helper-call-delegate": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
+          "integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-hoist-variables": "^7.4.4",
+            "@babel/traverse": "^7.4.4",
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/helper-define-map": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
+          "integrity": "sha512-fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/types": "^7.5.5",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
+          "integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
+          "integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.5.5"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
+          "integrity": "sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@babel/helper-simple-access": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.4.4",
+            "@babel/template": "^7.4.4",
+            "@babel/types": "^7.5.5",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/helper-regex": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
+          "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
+          "integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.5.5",
+            "@babel/helper-optimise-call-expression": "^7.0.0",
+            "@babel/traverse": "^7.5.5",
+            "@babel/types": "^7.5.5"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+          "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/helpers": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.2.tgz",
+          "integrity": "sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==",
+          "dev": true,
+          "requires": {
+            "@babel/template": "^7.6.0",
+            "@babel/traverse": "^7.6.2",
+            "@babel/types": "^7.6.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.6.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
+          "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
+          "dev": true
+        },
+        "@babel/plugin-proposal-object-rest-spread": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz",
+          "integrity": "sha512-LDBXlmADCsMZV1Y9OQwMc0MyGZ8Ta/zlD9N67BfQT8uYwkRswiu2hU6nJKrjrt/58aH/vqfQlR/9yId/7A2gWw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-unicode-property-regex": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.6.2.tgz",
+          "integrity": "sha512-NxHETdmpeSCtiatMRYWVJo7266rrvAC3DTeG5exQBIH/fMIUK7ejDNznBbn3HQl/o9peymRRg7Yqkx6PdUXmMw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-regex": "^7.4.4",
+            "regexpu-core": "^4.6.0"
+          }
+        },
+        "@babel/plugin-syntax-flow": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.2.0.tgz",
+          "integrity": "sha512-r6YMuZDWLtLlu0kqIim5o/3TNRAlWb073HwT3e2nKf9I8IIvOggPrnILYPsrrKilmn/mYEMCf/Z07w3yQJF6dg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-async-to-generator": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz",
+          "integrity": "sha512-mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-remap-async-to-generator": "^7.1.0"
+          }
+        },
+        "@babel/plugin-transform-block-scoping": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.3.tgz",
+          "integrity": "sha512-7hvrg75dubcO3ZI2rjYTzUrEuh1E9IyDEhhB6qfcooxhDA33xx2MasuLVgdxzcP6R/lipAC6n9ub9maNW6RKdw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/plugin-transform-classes": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz",
+          "integrity": "sha512-U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.0.0",
+            "@babel/helper-define-map": "^7.5.5",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-optimise-call-expression": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-replace-supers": "^7.5.5",
+            "@babel/helper-split-export-declaration": "^7.4.4",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/plugin-transform-destructuring": {
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.6.0.tgz",
+          "integrity": "sha512-2bGIS5P1v4+sWTCnKNDZDxbGvEqi0ijeqM/YqHtVGrvG2y0ySgnEEhXErvE9dA0bnIzY9bIzdFK0jFA46ASIIQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-dotall-regex": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.6.2.tgz",
+          "integrity": "sha512-KGKT9aqKV+9YMZSkowzYoYEiHqgaDhGmPNZlZxX6UeHC4z30nC1J9IrZuGqbYFB1jaIGdv91ujpze0exiVK8bA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-regex": "^7.4.4",
+            "regexpu-core": "^4.6.0"
+          }
+        },
+        "@babel/plugin-transform-duplicate-keys": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz",
+          "integrity": "sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-flow-strip-types": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.6.3.tgz",
+          "integrity": "sha512-l0ETkyEofkqFJ9LS6HChNIKtVJw2ylKbhYMlJ5C6df+ldxxaLIyXY4yOdDQQspfFpV8/vDiaWoJlvflstlYNxg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-flow": "^7.2.0"
+          }
+        },
+        "@babel/plugin-transform-for-of": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
+          "integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-function-name": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
+          "integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-modules-amd": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz",
+          "integrity": "sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-transforms": "^7.1.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "babel-plugin-dynamic-import-node": "^2.3.0"
+          }
+        },
+        "@babel/plugin-transform-modules-commonjs": {
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.6.0.tgz",
+          "integrity": "sha512-Ma93Ix95PNSEngqomy5LSBMAQvYKVe3dy+JlVJSHEXZR5ASL9lQBedMiCyVtmTLraIDVRE3ZjTZvmXXD2Ozw3g==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-transforms": "^7.4.4",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-simple-access": "^7.1.0",
+            "babel-plugin-dynamic-import-node": "^2.3.0"
+          }
+        },
+        "@babel/plugin-transform-modules-systemjs": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz",
+          "integrity": "sha512-Q2m56tyoQWmuNGxEtUyeEkm6qJYFqs4c+XyXH5RAuYxObRNz9Zgj/1g2GMnjYp2EUyEy7YTrxliGCXzecl/vJg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-hoist-variables": "^7.4.4",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "babel-plugin-dynamic-import-node": "^2.3.0"
+          }
+        },
+        "@babel/plugin-transform-named-capturing-groups-regex": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.3.tgz",
+          "integrity": "sha512-jTkk7/uE6H2s5w6VlMHeWuH+Pcy2lmdwFoeWCVnvIrDUnB5gQqTVI8WfmEAhF2CDEarGrknZcmSFg1+bkfCoSw==",
+          "dev": true,
+          "requires": {
+            "regexpu-core": "^4.6.0"
+          }
+        },
+        "@babel/plugin-transform-new-target": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
+          "integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-object-super": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz",
+          "integrity": "sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-replace-supers": "^7.5.5"
+          }
+        },
+        "@babel/plugin-transform-parameters": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
+          "integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-call-delegate": "^7.4.4",
+            "@babel/helper-get-function-arity": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-regenerator": {
+          "version": "7.4.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
+          "integrity": "sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==",
+          "dev": true,
+          "requires": {
+            "regenerator-transform": "^0.14.0"
+          }
+        },
+        "@babel/plugin-transform-spread": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.6.2.tgz",
+          "integrity": "sha512-DpSvPFryKdK1x+EDJYCy28nmAaIMdxmhot62jAXF/o99iA33Zj2Lmcp3vDmz+MUh0LNYVPvfj5iC3feb3/+PFg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-template-literals": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
+          "integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-unicode-regex": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.6.2.tgz",
+          "integrity": "sha512-orZI6cWlR3nk2YmYdb0gImrgCUwb5cBUwjf6Ks6dvNVvXERkwtJWOQaEOjPiu0Gu1Tq6Yq/hruCZZOOi9F34Dw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-regex": "^7.4.4",
+            "regexpu-core": "^4.6.0"
+          }
+        },
+        "@babel/preset-env": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.3.tgz",
+          "integrity": "sha512-CWQkn7EVnwzlOdR5NOm2+pfgSNEZmvGjOhlCHBDq0J8/EStr+G+FvPEiz9B56dR6MoiUFjXhfE4hjLoAKKJtIQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+            "@babel/plugin-proposal-dynamic-import": "^7.5.0",
+            "@babel/plugin-proposal-json-strings": "^7.2.0",
+            "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
+            "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
+            "@babel/plugin-proposal-unicode-property-regex": "^7.6.2",
+            "@babel/plugin-syntax-async-generators": "^7.2.0",
+            "@babel/plugin-syntax-dynamic-import": "^7.2.0",
+            "@babel/plugin-syntax-json-strings": "^7.2.0",
+            "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+            "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+            "@babel/plugin-transform-arrow-functions": "^7.2.0",
+            "@babel/plugin-transform-async-to-generator": "^7.5.0",
+            "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
+            "@babel/plugin-transform-block-scoping": "^7.6.3",
+            "@babel/plugin-transform-classes": "^7.5.5",
+            "@babel/plugin-transform-computed-properties": "^7.2.0",
+            "@babel/plugin-transform-destructuring": "^7.6.0",
+            "@babel/plugin-transform-dotall-regex": "^7.6.2",
+            "@babel/plugin-transform-duplicate-keys": "^7.5.0",
+            "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
+            "@babel/plugin-transform-for-of": "^7.4.4",
+            "@babel/plugin-transform-function-name": "^7.4.4",
+            "@babel/plugin-transform-literals": "^7.2.0",
+            "@babel/plugin-transform-member-expression-literals": "^7.2.0",
+            "@babel/plugin-transform-modules-amd": "^7.5.0",
+            "@babel/plugin-transform-modules-commonjs": "^7.6.0",
+            "@babel/plugin-transform-modules-systemjs": "^7.5.0",
+            "@babel/plugin-transform-modules-umd": "^7.2.0",
+            "@babel/plugin-transform-named-capturing-groups-regex": "^7.6.3",
+            "@babel/plugin-transform-new-target": "^7.4.4",
+            "@babel/plugin-transform-object-super": "^7.5.5",
+            "@babel/plugin-transform-parameters": "^7.4.4",
+            "@babel/plugin-transform-property-literals": "^7.2.0",
+            "@babel/plugin-transform-regenerator": "^7.4.5",
+            "@babel/plugin-transform-reserved-words": "^7.2.0",
+            "@babel/plugin-transform-shorthand-properties": "^7.2.0",
+            "@babel/plugin-transform-spread": "^7.6.2",
+            "@babel/plugin-transform-sticky-regex": "^7.2.0",
+            "@babel/plugin-transform-template-literals": "^7.4.4",
+            "@babel/plugin-transform-typeof-symbol": "^7.2.0",
+            "@babel/plugin-transform-unicode-regex": "^7.6.2",
+            "@babel/types": "^7.6.3",
+            "browserslist": "^4.6.0",
+            "core-js-compat": "^3.1.1",
+            "invariant": "^2.2.2",
+            "js-levenshtein": "^1.1.3",
+            "semver": "^5.5.0"
+          }
+        },
+        "@babel/runtime": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
+          "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "@babel/template": {
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
+          "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.6.0",
+            "@babel/types": "^7.6.0"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
+          "integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.5.5",
+            "@babel/generator": "^7.6.3",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.4.4",
+            "@babel/parser": "^7.6.3",
+            "@babel/types": "^7.6.3",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.5.5",
+              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+              "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+              "dev": true,
+              "requires": {
+                "@babel/highlight": "^7.0.0"
+              }
+            }
+          }
+        },
+        "@babel/types": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
+          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "babel-plugin-dynamic-import-node": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+          "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+          "dev": true,
+          "requires": {
+            "object.assign": "^4.1.0"
+          }
+        },
         "browserslist": {
           "version": "4.7.0",
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.0.tgz",
@@ -14696,9 +15621,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30000997",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000997.tgz",
-          "integrity": "sha512-BQLFPIdj2ntgBNWp9Q64LGUIEmvhKkzzHhUHR3CD5A9Lb7ZKF20/+sgadhFap69lk5XmK1fTUleDclaRFvgVUA==",
+          "version": "1.0.30000999",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000999.tgz",
+          "integrity": "sha512-1CUyKyecPeksKwXZvYw0tEoaMCo/RwBlXmEtN5vVnabvO0KPd9RQLcaAuR9/1F+KDMv6esmOFWlsXuzDk+8rxg==",
           "dev": true
         },
         "cross-spawn": {
@@ -14714,10 +15639,25 @@
             "which": "^1.2.9"
           }
         },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
         "electron-to-chromium": {
-          "version": "1.3.269",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.269.tgz",
-          "integrity": "sha512-t2ZTfo07HxkxTOUbIwMmqHBSnJsC9heqJUm7LwQu2iSk0wNhG4H5cMREtb8XxeCrQABDZ6IqQKY3yZq+NfAqwg==",
+          "version": "1.3.282",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.282.tgz",
+          "integrity": "sha512-irSaDeCGgfMu1OA30bhqIBr+dx+pDJjRbwCpob7YWqVZbzXblybNzPGklVnWqv4EXxbkEAzQYqiNCqNTgu00lQ==",
+          "dev": true
+        },
+        "envinfo": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.4.0.tgz",
+          "integrity": "sha512-FdDfnWnCVjxTTpWE3d6Jgh5JDIA3Cw7LCgpM/pI7kK1ORkjaqI2r6NqQ+ln2j0dfpgxY00AWieSvtkiZQKIItA==",
           "dev": true
         },
         "json5": {
@@ -14730,12 +15670,58 @@
           }
         },
         "node-releases": {
-          "version": "1.1.33",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.33.tgz",
-          "integrity": "sha512-I0V30bWQEoHb+10W8oedVoUrdjW5wIkYm0w7vvcrPO95pZY738m1k77GF5sO0vKg5eXYg9oGtrMAETbgZGm11A==",
+          "version": "1.1.36",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.36.tgz",
+          "integrity": "sha512-ggXhX6QGyJSjj3r+6ml2LqqC28XOWmKtpb+a15/Zpr9V3yoNazxJNlcQDS9bYaid5FReEWHEgToH1mwoUceWwg==",
           "dev": true,
           "requires": {
-            "semver": "^5.3.0"
+            "semver": "^6.3.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
+          }
+        },
+        "regenerate-unicode-properties": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+          "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.4.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+          "dev": true
+        },
+        "regenerator-transform": {
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
+          "integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
+          "dev": true,
+          "requires": {
+            "private": "^0.1.6"
+          }
+        },
+        "regexpu-core": {
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
+          "integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.4.0",
+            "regenerate-unicode-properties": "^8.1.0",
+            "regjsgen": "^0.5.0",
+            "regjsparser": "^0.6.0",
+            "unicode-match-property-ecmascript": "^1.0.4",
+            "unicode-match-property-value-ecmascript": "^1.1.0"
           }
         },
         "source-map": {
@@ -14743,21 +15729,27 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
+        },
+        "unicode-match-property-value-ecmascript": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+          "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
+          "dev": true
         }
       }
     },
     "parent-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
-      "integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "requires": {
         "callsites": "^3.0.0"
       },
       "dependencies": {
         "callsites": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
-          "integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw=="
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
         }
       }
     },
@@ -15844,10 +16836,19 @@
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
     "prettier": {
-      "version": "1.16.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
-      "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
       "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "pretty-bytes": {
       "version": "4.0.2",
@@ -15930,12 +16931,6 @@
       "requires": {
         "xtend": "^4.0.1"
       }
-    },
-    "proto-list": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-      "dev": true
     },
     "proxy-addr": {
       "version": "2.0.4",
@@ -17087,15 +18082,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "safer-eval": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/safer-eval/-/safer-eval-1.3.5.tgz",
-      "integrity": "sha512-BJ//K2Y+EgCbOHEsDGS5YahYBcYy7JcFpKDo2ba5t4MnOGHYtk7HvQkcxTDFvjQvJ0CRcdas/PyF+gTTCay+3w==",
-      "dev": true,
-      "requires": {
-        "clones": "^1.2.0"
-      }
-    },
     "sanitize-html": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.20.0.tgz",
@@ -17266,14 +18252,10 @@
       "integrity": "sha512-A5MOagrPFga4YaKQSWHryl7AXvbQkEqpw4NNYMTNYUNV51bA8ABHgYFpqKx+YFFrw59xMV1qGH1R4AgoNIVgCw=="
     },
     "serialize-to-js": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
-      "integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
-      "dev": true,
-      "requires": {
-        "js-beautify": "^1.8.9",
-        "safer-eval": "^1.3.0"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-3.0.0.tgz",
+      "integrity": "sha512-WdGgi0jGnWCQXph2p3vkxceDnTfvfyXfYxherQMRcZjSaJzMQdMBAW6i0nojsBKIZ3fFOztZKKVbbm05VbIdRA==",
+      "dev": true
     },
     "serve-index": {
       "version": "1.9.1",
@@ -17443,12 +18425,6 @@
       "version": "5.1.0",
       "resolved": "http://registry.npmjs.org/sift/-/sift-5.1.0.tgz",
       "integrity": "sha1-G78t+w63HlbEzH+1Z/vRNRtlAV4="
-    },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-      "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -18186,6 +19162,24 @@
         "function-bind": "^1.0.2"
       }
     },
+    "string.prototype.trimleft": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -18504,20 +19498,31 @@
       "dev": true
     },
     "table": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
-      "integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
       "requires": {
-        "ajv": "^6.9.1",
-        "lodash": "^4.17.11",
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
         "slice-ansi": "^2.1.0",
         "string-width": "^3.0.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
         "ansi-regex": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -18525,21 +19530,21 @@
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "string-width": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.0.0.tgz",
-          "integrity": "sha512-rr8CUxBbvOZDUvc5lNIJ+OC1nPVpz+Siw9VBtUjB9b6jZehZLFt0JMCZzShFHIsI8cbhm0EsNIfWJMFV3cu3Ew==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.0.0"
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "requires": {
-            "ansi-regex": "^4.0.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -19146,9 +20151,9 @@
       },
       "dependencies": {
         "commander": {
-          "version": "2.20.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
-          "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==",
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true
         },
         "glob": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx}": [
       "eslint --fix",
-      "prettier —write",
+      "prettier —-write",
       "npm test",
       "git add"
     ]

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "eslint": "^6.5.1",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-prettier": "^6.4.0",
+    "eslint-formatter-summary": "^1.0.4",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.1.1",
@@ -81,9 +82,10 @@
     }
   },
   "lint-staged": {
-    "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
-      "eslint src/**/* --fix",
+    "src/**/*.{js,jsx,ts,tsx}": [
+      "eslint --fix",
       "prettier —write",
+      "jest test",
       "git add"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -68,9 +68,22 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-react": "^7.16.0",
+    "husky": "^3.0.9",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^24.1.0",
+    "lint-staged": "^9.4.2",
     "parcel-bundler": "^1.12.4",
     "prettier": "^1.18.2"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.js": [
+      "eslint",
+      "git add"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -81,8 +81,8 @@
     }
   },
   "lint-staged": {
-    "*.js": [
-      "eslint",
+    "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
+      "prettier —write",
       "git add"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
   },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
+      "eslint src/**/* --fix",
       "prettier —write",
       "git add"
     ]

--- a/package.json
+++ b/package.json
@@ -59,10 +59,18 @@
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-react": "^7.0.0",
     "babel-core": "^7.0.0-bridge.0",
+    "babel-eslint": "^10.0.3",
     "babel-jest": "^24.9.0",
+    "eslint": "^6.5.1",
+    "eslint-config-airbnb": "^18.0.1",
+    "eslint-config-prettier": "^6.4.0",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-jsx-a11y": "^6.2.3",
+    "eslint-plugin-prettier": "^3.1.1",
+    "eslint-plugin-react": "^7.16.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^24.1.0",
-    "parcel-bundler": "^1.12.3",
-    "prettier": "^1.16.4"
+    "parcel-bundler": "^1.12.4",
+    "prettier": "^1.18.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "src/**/*.{js,jsx,ts,tsx}": [
       "eslint --fix",
       "prettier —write",
-      "jest test",
+      "npm test",
       "git add"
     ]
   }

--- a/src/components/DocsViewer.js
+++ b/src/components/DocsViewer.js
@@ -1,6 +1,7 @@
-import React from 'react'
-import _ from 'lodash'
-import styles from '../styles.module.css'
+import React from 'react';
+import _ from 'lodash';
+import styles from '../styles.module.css';
+
 const webpackDocsMap = {
   Vue: (
     <div>
@@ -213,7 +214,7 @@ const webpackDocsMap = {
       </p>
     </div>
   ),
-}
+};
 
 const parcelDocsMap = {
   Babel: (
@@ -255,7 +256,7 @@ const parcelDocsMap = {
       </p>
     </div>
   ),
-}
+};
 
 const commonDocsMap = {
   React: (
@@ -283,24 +284,27 @@ const commonDocsMap = {
       </p>
     </div>
   ),
-}
+};
 export const docsMap = buildTool =>
   buildTool === 'webpack'
     ? _.assign({}, webpackDocsMap, commonDocsMap)
-    : _.assign({}, parcelDocsMap, commonDocsMap)
+    : _.assign({}, parcelDocsMap, commonDocsMap);
 
 export default function DocsViewer({
   hoverFeature,
   selectedFeatures,
   buildTool,
 }) {
-  const hoverSelectedFeature = _.find(selectedFeatures, f => hoverFeature === f)
+  const hoverSelectedFeature = _.find(
+    selectedFeatures,
+    f => hoverFeature === f
+  );
 
-  const theDoc = docsMap(buildTool)[hoverSelectedFeature]
+  const theDoc = docsMap(buildTool)[hoverSelectedFeature];
 
   if (!hoverSelectedFeature || !theDoc) {
-    return null
+    return null;
   }
 
-  return <div className={styles.docsContainer}>{theDoc}</div>
+  return <div className={styles.docsContainer}>{theDoc}</div>;
 }

--- a/src/components/FileBrowser.js
+++ b/src/components/FileBrowser.js
@@ -1,20 +1,20 @@
-import React from 'react'
-import _ from 'lodash'
+import React from 'react';
+import _ from 'lodash';
 
-import styles from '../styles.module.css'
-import '../vendor/prism-line-highlight.css'
-import Prism from 'prismjs'
-import memoizee from 'memoizee'
-import { getNpmDependencies } from '../configurator/configurator'
-import { getDiffAsLineNumber } from '../configurator/Diff'
-import npmVersionPromise from '../fetch-npm-version'
+import '../vendor/prism-line-highlight.css';
+import Prism from 'prismjs';
+import memoizee from 'memoizee';
+import styles from '../styles.module.css';
+import { getNpmDependencies } from '../configurator/configurator';
+import { getDiffAsLineNumber } from '../configurator/Diff';
+import npmVersionPromise from '../fetch-npm-version';
 
 // disable prettier for now.
 // import prettier from 'prettier/standalone'
 // const parserBabylon = require('prettier/parser-babylon')
 
-require('prismjs/themes/prism-tomorrow.css')
-require('../vendor/PrismLineHighlight')
+require('prismjs/themes/prism-tomorrow.css');
+require('../vendor/PrismLineHighlight');
 
 const FileList = ({ files, selectedFile, onSelectFile }) => {
   // sort with folders on top, and in alphabetic order
@@ -23,7 +23,7 @@ const FileList = ({ files, selectedFile, onSelectFile }) => {
     .groupBy(({ filename }) => _.includes(filename, '/'))
     .mapValues(group => _.sortBy(group, 'filename'))
     .reduce((all, value, key) => _.concat(value, all), [])
-    .value()
+    .value();
 
   // group adjacent files that are highlighted
   // so that we can highlight  more than one
@@ -32,19 +32,18 @@ const FileList = ({ files, selectedFile, onSelectFile }) => {
     sortedFiles,
     (result, { filename, highlightedFile }) => {
       // get last group in list.
-      const lastGroup = _.last(result)
+      const lastGroup = _.last(result);
       if (lastGroup && _.get(lastGroup, 'highlighted') === !!highlightedFile) {
-        lastGroup.files.push(filename)
-        return result
-      } else {
-        return _.concat(result, {
-          highlighted: !!highlightedFile,
-          files: [filename],
-        })
+        lastGroup.files.push(filename);
+        return result;
       }
+      return _.concat(result, {
+        highlighted: !!highlightedFile,
+        files: [filename],
+      });
     },
     []
-  )
+  );
 
   const filesElements = _.map(groupByHighlight, ({ highlighted, files }, i) => (
     <div className={highlighted ? styles.highlighted : null} key={i}>
@@ -58,29 +57,31 @@ const FileList = ({ files, selectedFile, onSelectFile }) => {
         </li>
       ))}
     </div>
-  ))
+  ));
 
   return (
     <div className={styles.files}>
       <ul>{filesElements}</ul>
     </div>
-  )
-}
+  );
+};
 
 class CodeBox extends React.Component {
   componentDidMount() {
-    Prism.highlightAll()
+    Prism.highlightAll();
   }
+
   componentDidUpdate(props) {
     if (
       props.code !== this.props.code ||
       props.highlightedLines !== this.props.highlightedLines
     ) {
-      Prism.highlightAll()
+      Prism.highlightAll();
     }
   }
+
   render() {
-    const { code, highlightedLines } = this.props
+    const { code, highlightedLines } = this.props;
 
     return (
       <div className={styles.codeBox}>
@@ -88,21 +89,22 @@ class CodeBox extends React.Component {
           <code className="language-javascript">{code}</code>
         </pre>
       </div>
-    )
+    );
   }
 }
 
-const filenameRegex = /.+\./i
-const extensionRegex = /\.[0-9a-z]+$/i
+const filenameRegex = /.+\./i;
+const extensionRegex = /\.[0-9a-z]+$/i;
 
 class FileBrowser extends React.Component {
   constructor(props) {
-    super(props)
+    super(props);
     this.state = {
       selectedFile: props.defaultSelection,
-    }
-    this.setSelectedFile = this.setSelectedFile.bind(this)
+    };
+    this.setSelectedFile = this.setSelectedFile.bind(this);
   }
+
   componentDidUpdate(prevProps) {
     if (this.props.fileContentMap !== prevProps.fileContentMap) {
       if (
@@ -114,29 +116,31 @@ class FileBrowser extends React.Component {
         // but different extension
         // for example if previous was index.js maybe new one is index.ts
 
-        const filename = this.state.selectedFile.match(filenameRegex)
+        const filename = this.state.selectedFile.match(filenameRegex);
         const newSelection = _.find(
           _.keys(this.props.fileContentMap),
           // we don't want to go from index.js to index.html
           file => _.startsWith(file, filename) && !_.endsWith(file, 'html')
-        )
+        );
         this.setState({
           selectedFile: newSelection || this.props.defaultSelection,
-        })
+        });
       }
     }
   }
+
   setSelectedFile(selectedFile) {
-    this.setState({ selectedFile })
+    this.setState({ selectedFile });
     if (selectedFile === 'package.json') {
-      this.props.onSelectPackageJson()
+      this.props.onSelectPackageJson();
     }
   }
-  render() {
-    const { fileContentMap } = this.props
-    const fileContent = _.get(fileContentMap, this.state.selectedFile, '')
 
-    const extension = this.state.selectedFile.match(extensionRegex)
+  render() {
+    const { fileContentMap } = this.props;
+    const fileContent = _.get(fileContentMap, this.state.selectedFile, '');
+
+    const extension = this.state.selectedFile.match(extensionRegex);
 
     return (
       <div className={styles.fileBrowser} id="file-browser">
@@ -151,7 +155,7 @@ class FileBrowser extends React.Component {
           highlightedLines={fileContent.highlightedLines}
         />
       </div>
-    )
+    );
   }
 }
 /*
@@ -164,54 +168,56 @@ class FileBrowser extends React.Component {
   the whole file should be highlighted
 */
 class FileBrowserTransformer extends React.Component {
-  getDiffAsLineNumberMemoized = memoizee(getDiffAsLineNumber)
+  getDiffAsLineNumberMemoized = memoizee(getDiffAsLineNumber);
+
   render() {
     const fileContentMap = _.mapValues(this.props.files, (content, name) => {
-      let highlightedLines
-      let highlightedFile = false
+      let highlightedLines;
+      let highlightedFile = false;
       // if the file didn't exist previously, highlight it all
       if (!content.previousContent) {
-        highlightedFile = true
-        const lines = content.currentContent.split(/\r\n|\r|\n/).length
-        highlightedLines = `1-${lines}`
+        highlightedFile = true;
+        const lines = content.currentContent.split(/\r\n|\r|\n/).length;
+        highlightedLines = `1-${lines}`;
       } else if (content.previousContent !== content.currentContent) {
-        //highlightedFile = true
+        // highlightedFile = true
         highlightedLines = this.getDiffAsLineNumberMemoized(
           content.previousContent,
           content.currentContent
-        )
+        );
       }
 
       return {
         content: content.currentContent,
         highlightedLines,
         highlightedFile,
-      }
-    })
+      };
+    });
     return (
       <FileBrowser
         onSelectPackageJson={this.props.onSelectPackageJson}
         fileContentMap={fileContentMap}
         defaultSelection={this.props.defaultSelection}
       />
-    )
+    );
   }
 }
 
 class FileBrowserContainer extends React.Component {
   constructor(props) {
-    super(props)
+    super(props);
 
     const projectFiles = this.props.projectGeneratorFunction(
       this.props.features,
       'empty-project'
-    )
+    );
 
     this.state = {
       projectFiles,
       projectFilesWithoutHighlightedFeature: projectFiles,
-    }
+    };
   }
+
   /**
      load all version of dependencies (and cache them) used on page load
      to get a quicker loading speed when we show them.
@@ -220,32 +226,35 @@ class FileBrowserContainer extends React.Component {
     const npmConfigAllFeatures = getNpmDependencies(
       this.props.featureConfig,
       _.keys(this.props.featureConfig.features)
-    )
+    );
     const allDependencies = _.concat(
       npmConfigAllFeatures.dependencies,
       npmConfigAllFeatures.devDependencies
-    )
-    _.forEach(allDependencies, dependency => npmVersionPromise(dependency))
+    );
+    _.forEach(allDependencies, dependency => npmVersionPromise(dependency));
   }
+
   componentDidUpdate(prevProps) {
     if (
       !_.isEqual(this.props.highlightFeature, prevProps.highlightFeature) ||
       !_.isEqual(this.props.features, prevProps.features) ||
       !_.isEqual(this.props.featureConfig, prevProps.featureConfig)
     ) {
-      this.setProjectFilesInState()
+      this.setProjectFilesInState();
     }
   }
+
   componentDidMount() {
     // fetch first without packagejson because package.json
     // is slow because we need to fetch versions.
-    this.setProjectFilesInState()
-    this.loadAllDependencyVersions()
+    this.setProjectFilesInState();
+    this.loadAllDependencyVersions();
   }
 
   getAllFeaturesExceptHighlighted = memoizee((features, highlightFeature) =>
     _.reject(features, f => f === highlightFeature)
-  )
+  );
+
   setProjectFilesInState = () => {
     this.props
       .projectGeneratorFunction(
@@ -254,18 +263,18 @@ class FileBrowserContainer extends React.Component {
         npmVersionPromise
       )
       .then(files => {
-        this.setState({ projectFiles: files })
+        this.setState({ projectFiles: files });
         if (!this.props.highlightFeature) {
           // beacuse if there is no highligthed, then the previous content is the same as current content
-          this.setState({ projectFilesWithoutHighlightedFeature: files })
+          this.setState({ projectFilesWithoutHighlightedFeature: files });
         }
-      })
+      });
 
     if (this.props.highlightFeature) {
       const featuresWithoutHighlighted = this.getAllFeaturesExceptHighlighted(
         this.props.features,
         this.props.highlightFeature
-      )
+      );
       this.props
         .projectGeneratorFunction(
           featuresWithoutHighlighted,
@@ -275,32 +284,35 @@ class FileBrowserContainer extends React.Component {
         .then(files => {
           this.setState({
             projectFilesWithoutHighlightedFeature: files,
-          })
-        })
+          });
+        });
     }
-  }
+  };
+
   render() {
-    const projectFiles = this.state.projectFiles
+    const { projectFiles } = this.state;
 
     const files = _.mapValues(projectFiles, (currentContent, file) => {
-      let previousContent
+      let previousContent;
       if (this.state.projectFilesWithoutHighlightedFeature[file]) {
-        previousContent = this.state.projectFilesWithoutHighlightedFeature[file]
+        previousContent = this.state.projectFilesWithoutHighlightedFeature[
+          file
+        ];
       }
 
       return {
         currentContent,
         previousContent,
-      }
-    })
+      };
+    });
     return (
       <FileBrowserTransformer
         onSelectPackageJson={() => this.setProjectFilesInState()}
         defaultSelection={this.props.defaultFile || 'webpack.config.js'}
         files={files}
       />
-    )
+    );
   }
 }
 
-export default FileBrowserContainer
+export default FileBrowserContainer;

--- a/src/components/SignupForms.js
+++ b/src/components/SignupForms.js
@@ -1,7 +1,7 @@
-import React, { useState } from 'react'
-import styles from '../styles.module.css'
+import React, { useState } from 'react';
+import styles from '../styles.module.css';
 
-/*DRIP form. currently not in use.*/
+/* DRIP form. currently not in use. */
 // eslint-disable-next-line
 const SignupForm = ({ buttonText, buttonStyle, signupText, dripId }) => (
   <div className={styles.signupFormArea}>
@@ -12,7 +12,7 @@ const SignupForm = ({ buttonText, buttonStyle, signupText, dripId }) => (
     >
       <div>
         <input
-          autoFocus={true}
+          autoFocus
           className={styles.signupField}
           placeholder="Your Email"
           type="email"
@@ -41,7 +41,7 @@ const SignupForm = ({ buttonText, buttonStyle, signupText, dripId }) => (
       </div>
     </form>
   </div>
-)
+);
 
 function ConvertKitSignupForm({
   children,
@@ -51,22 +51,22 @@ function ConvertKitSignupForm({
   formId = '915821',
   tags,
 }) {
-  const [errorMessage, setErrorMessage] = useState('')
-  const [email, setEmail] = useState('')
-  const [name, setName] = useState('')
+  const [errorMessage, setErrorMessage] = useState('');
+  const [email, setEmail] = useState('');
+  const [name, setName] = useState('');
 
   const clearError = () => {
     if (email !== '' && name !== '') {
-      setErrorMessage('')
+      setErrorMessage('');
     }
-  }
+  };
 
   const onSubmit = e => {
     if (email === '' || name === '') {
-      setErrorMessage('Please no empty inputs')
-      e.preventDefault()
+      setErrorMessage('Please no empty inputs');
+      e.preventDefault();
     }
-  }
+  };
   return (
     <div className={styles.signupFormArea}>
       <form
@@ -80,13 +80,13 @@ function ConvertKitSignupForm({
           <input
             className={styles.signupField}
             onChange={e => {
-              clearError()
-              setEmail(e.target.value)
+              clearError();
+              setEmail(e.target.value);
             }}
             style={
               errorMessage && email === '' ? { border: '1px solid red' } : {}
             }
-            autoFocus={true}
+            autoFocus
             placeholder="Your Email"
             name="email_address"
             type="email"
@@ -96,8 +96,8 @@ function ConvertKitSignupForm({
           <input
             className={styles.signupField}
             onChange={e => {
-              clearError()
-              setName(e.target.value)
+              clearError();
+              setName(e.target.value);
             }}
             style={
               errorMessage && name === '' ? { border: '1px solid red' } : {}
@@ -123,19 +123,21 @@ function ConvertKitSignupForm({
         </div>
       </form>
     </div>
-  )
+  );
 }
 
 export function withHidden(WrappedComponent, text) {
   return class extends React.Component {
     constructor(props) {
-      super(props)
-      this.state = { hidden: true }
-      this.show = this.show.bind(this)
+      super(props);
+      this.state = { hidden: true };
+      this.show = this.show.bind(this);
     }
+
     show() {
-      this.setState({ hidden: false })
+      this.setState({ hidden: false });
     }
+
     render() {
       return (
         <div>
@@ -147,9 +149,9 @@ export function withHidden(WrappedComponent, text) {
             <WrappedComponent {...this.props} />
           )}
         </div>
-      )
+      );
     }
-  }
+  };
 }
 
 export const SampleChapterSignupForm = ({ buttonText }) => (
@@ -159,12 +161,12 @@ export const SampleChapterSignupForm = ({ buttonText }) => (
     signupText="You'll also get articles related to webpack and JavaScript once or twice per month"
     formId="918254"
   />
-)
+);
 
 export const GenericSignupForm = ({ buttonText }) => (
-  <ConvertKitSignupForm buttonText={'Sign up'} formId="931959" />
-)
+  <ConvertKitSignupForm buttonText="Sign up" formId="931959" />
+);
 
 export const CourseSignupForm = ({ buttonText, tags }) => (
   <ConvertKitSignupForm buttonText={buttonText} formId="917789" tags={tags} />
-)
+);

--- a/src/components/configurator/Features.js
+++ b/src/components/configurator/Features.js
@@ -1,30 +1,30 @@
-import React, { useState, useEffect, useRef } from 'react'
-import _ from 'lodash'
-import styles from '../../styles.module.css'
-import Modal from 'react-modal'
-import { docsMap } from '../DocsViewer'
-import { gaSendEvent } from '../../googleAnalytics'
+import React, { useState, useEffect, useRef } from 'react';
+import _ from 'lodash';
+import Modal from 'react-modal';
+import styles from '../../styles.module.css';
+import { docsMap } from '../DocsViewer';
+import { gaSendEvent } from '../../googleAnalytics';
 
 function trackHelpIconClick(eventAction) {
   gaSendEvent({
     eventCategory: 'Help Icon clicked',
     eventAction,
-  })
+  });
 }
 
 // eslint-disable-next-line no-unused-vars
 function FeedbackForm({ feature, children }) {
-  const [email, setEmail] = useState('')
-  const [comment, setComment] = useState('')
-  const [isSent, setIsSent] = useState(false)
+  const [email, setEmail] = useState('');
+  const [comment, setComment] = useState('');
+  const [isSent, setIsSent] = useState(false);
   const submit = e => {
-    e.preventDefault()
+    e.preventDefault();
     fetch(`https://hooks.zapier.com/hooks/catch/1239764/oo73gyz/`, {
       method: 'POST',
       body: JSON.stringify({ email, comment, key: feature }),
-    }).then(() => setIsSent(true))
-  }
-  const thankYouMessage = <p>Thank you for your input!</p>
+    }).then(() => setIsSent(true));
+  };
+  const thankYouMessage = <p>Thank you for your input!</p>;
   const form = (
     <>
       {children}
@@ -52,22 +52,22 @@ function FeedbackForm({ feature, children }) {
         <br />
       </form>
     </>
-  )
-  return <>{isSent ? thankYouMessage : form}</>
+  );
+  return <>{isSent ? thankYouMessage : form}</>;
 }
 
 function FeatureHelp({ featureName, selectedBuildTool }) {
-  const [modalOpen, setModalOpen] = useState(false)
-  const helpText = docsMap(selectedBuildTool)[featureName]
+  const [modalOpen, setModalOpen] = useState(false);
+  const helpText = docsMap(selectedBuildTool)[featureName];
   if (!helpText) {
-    return null
+    return null;
   }
   return (
     <>
       <button
         onClick={() => {
-          trackHelpIconClick(featureName)
-          setModalOpen(true)
+          trackHelpIconClick(featureName);
+          setModalOpen(true);
         }}
         className={styles.helpCircle}
       >
@@ -91,7 +91,7 @@ function FeatureHelp({ featureName, selectedBuildTool }) {
         {helpText}
       </Modal>
     </>
-  )
+  );
 }
 const Feature = ({
   feature,
@@ -120,13 +120,13 @@ const Feature = ({
     </label>
     <FeatureHelp featureName={feature} selectedBuildTool={selectedBuildTool} />
   </>
-)
+);
 function usePrevious(value) {
-  const ref = useRef()
+  const ref = useRef();
   useEffect(() => {
-    ref.current = value
-  })
-  return ref.current
+    ref.current = value;
+  });
+  return ref.current;
 }
 
 function FeatureGroup({
@@ -138,10 +138,8 @@ function FeatureGroup({
   onMouseLeave,
   selectedBuildTool,
 }) {
-  const [expanded, setExpanded] = useState(
-    group === 'Main library' ? true : false
-  )
-  const prevSelected = usePrevious(selected)
+  const [expanded, setExpanded] = useState(group === 'Main library');
+  const prevSelected = usePrevious(selected);
   useEffect(() => {
     const anyChanged = _.reduce(
       featureList,
@@ -149,14 +147,14 @@ function FeatureGroup({
         return (
           result ||
           selected[feature] !== (prevSelected && prevSelected[feature])
-        )
+        );
       },
       false
-    )
+    );
     if (anyChanged) {
-      setExpanded(true)
+      setExpanded(true);
     }
-  }, [selected])
+  }, [selected]);
 
   return (
     <div className={styles.featureGroup}>
@@ -182,7 +180,7 @@ function FeatureGroup({
         </div>
       ) : null}
     </div>
-  )
+  );
 }
 
 export default class Features extends React.Component {
@@ -194,11 +192,11 @@ export default class Features extends React.Component {
       onMouseEnter,
       onMouseLeave,
       selectedBuildTool,
-    } = this.props
+    } = this.props;
     const groupedFeatures = _.chain(features)
-      .mapValues((v, k, o) => Object.assign({}, v, { feature: k }))
+      .mapValues((v, k, o) => ({ ...v, feature: k }))
       .groupBy('group')
-      .value()
+      .value();
 
     return (
       <div className={styles.features} id="features">
@@ -215,7 +213,7 @@ export default class Features extends React.Component {
           />
         ))}
       </div>
-    )
+    );
   }
 }
 
@@ -233,18 +231,19 @@ function enforceEitherReactOrVue(
     return {
       ...allFeatureStates,
       React: !setToSelected,
-    }
+    };
     // deselect vue if user selects react
-  } else if (affectedFeature === 'React') {
+  }
+  if (affectedFeature === 'React') {
     if (setToSelected) {
       return {
         ...allFeatureStates,
         Vue: !setToSelected,
-      }
+      };
     }
   }
 
-  return allFeatureStates
+  return allFeatureStates;
 }
 
 function addOrRemoveReactHotLoader(
@@ -252,26 +251,26 @@ function addOrRemoveReactHotLoader(
   affectedFeature,
   setToSelected
 ) {
-  let setReactHotLoader
+  let setReactHotLoader;
 
   if (affectedFeature === 'Vue' && setToSelected) {
-    setReactHotLoader = false
+    setReactHotLoader = false;
   }
 
   if (affectedFeature === 'React') {
     if (setToSelected) {
-      setReactHotLoader = true
+      setReactHotLoader = true;
     } else {
-      setReactHotLoader = false
+      setReactHotLoader = false;
     }
   }
   if (setReactHotLoader === undefined) {
-    return allFeatureStates
+    return allFeatureStates;
   }
   return {
     ...allFeatureStates,
     'React hot loader': setReactHotLoader,
-  }
+  };
 }
 
 function stopIfNotBabelOrTypescriptForReact(
@@ -283,20 +282,20 @@ function stopIfNotBabelOrTypescriptForReact(
   if (
     affectedFeature === 'Babel' &&
     !setToSelected &&
-    allFeatureStates['React'] &&
-    !allFeatureStates['Typescript']
+    allFeatureStates.React &&
+    !allFeatureStates.Typescript
   ) {
-    return true
+    return true;
   }
   if (
     affectedFeature === 'Typescript' &&
     !setToSelected &&
-    allFeatureStates['React'] &&
-    !allFeatureStates['Babel']
+    allFeatureStates.React &&
+    !allFeatureStates.Babel
   ) {
-    return true
+    return true;
   }
-  return false
+  return false;
   //
 }
 
@@ -305,12 +304,12 @@ function removeEslintIfTypscript(
   affectedFeature,
   setToSelected
 ) {
-  const toTypescript = affectedFeature === 'Typescript' && setToSelected
+  const toTypescript = affectedFeature === 'Typescript' && setToSelected;
 
   return {
     ...allFeatureStates,
-    ESLint: toTypescript ? false : allFeatureStates['ESLint'],
-  }
+    ESLint: toTypescript ? false : allFeatureStates.ESLint,
+  };
 }
 
 function addCssIfPostCSS(allFeatureStates, affectedFeature, setToSelected) {
@@ -319,18 +318,17 @@ function addCssIfPostCSS(allFeatureStates, affectedFeature, setToSelected) {
     CSS:
       affectedFeature === 'PostCSS' && setToSelected
         ? true
-        : allFeatureStates['CSS'],
-  }
+        : allFeatureStates.CSS,
+  };
 }
 
 function addBabelIfReact(allFeatureStates, affectedFeature, setToSelected) {
-  const forceBabel =
-    allFeatureStates['React'] && !allFeatureStates['Typescript']
+  const forceBabel = allFeatureStates.React && !allFeatureStates.Typescript;
 
   return {
     ...allFeatureStates,
-    Babel: forceBabel || allFeatureStates['Babel'],
-  }
+    Babel: forceBabel || allFeatureStates.Babel,
+  };
 }
 
 // these are all possible selection rules.
@@ -349,12 +347,12 @@ export const selectionRules = {
     addCssIfPostCSS,
     removeEslintIfTypscript,
   },
-}
+};
 // eslint-disable-next-line
 const logFeaturCelickToGa = (feature, selected) => {
-  //const eventAction = selected ? 'select' : 'deselect'
-  /*window.gtag('event', eventAction, {
+  // const eventAction = selected ? 'select' : 'deselect'
+  /* window.gtag('event', eventAction, {
     event_category: 'features',
     event_label: feature,
-  })*/
-}
+  }) */
+};

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,5 +1,5 @@
-import React from 'react'
-import { Link } from 'gatsby'
+import React from 'react';
+import { Link } from 'gatsby';
 
 const Header = ({ siteTitle }) => (
   <div>
@@ -17,6 +17,6 @@ const Header = ({ siteTitle }) => (
       </h1>
     </div>
   </div>
-)
+);
 
-export default Header
+export default Header;

--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -1,50 +1,47 @@
 html {
-  font-family:"Helvetica Neue", Arial, sans-serif;
+  font-family: 'Helvetica Neue', Arial, sans-serif;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
 }
 body {
-    margin: 0;
-    margin-bottom: 100px;
-    font-size: large;
+  margin: 0;
+  margin-bottom: 100px;
+  font-size: large;
 }
 h1 {
-    font-size: small;
+  font-size: small;
 }
 
 h2 {
-    margin-top: 0px;
+  margin-top: 0px;
 }
 
 h3 {
-
-    clear:both;
+  clear: both;
 }
 
 ol {
-    counter-reset:li;
+  counter-reset: li;
 }
 ol li {
-    position: relative;
-    list-style:none;
-    margin-bottom: 20px;
-
+  position: relative;
+  list-style: none;
+  margin-bottom: 20px;
 }
 ol li:before {
-    content:counter(li);
-    counter-increment:li;
-    position:absolute;
-    top:-11px;
-    left:-2em;
-    width:2em;
-    margin-right:8px;
-    padding:4px;
-    font-size: 27px;
-    font-weight:bold;
-    font-family:"Helvetica Neue", Arial, sans-serif;
-    text-align:center;
+  content: counter(li);
+  counter-increment: li;
+  position: absolute;
+  top: -11px;
+  left: -2em;
+  width: 2em;
+  margin-right: 8px;
+  padding: 4px;
+  font-size: 27px;
+  font-weight: bold;
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  text-align: center;
 }
-
 
 html {
   box-sizing: border-box;
@@ -65,34 +62,33 @@ body {
   font-weight: normal;
   word-wrap: break-word;
   font-kerning: normal;
-  -moz-font-feature-settings: "kern", "liga", "clig", "calt";
-  -ms-font-feature-settings: "kern", "liga", "clig", "calt";
-  -webkit-font-feature-settings: "kern", "liga", "clig", "calt";
-  font-feature-settings: "kern", "liga", "clig", "calt";
+  -moz-font-feature-settings: 'kern', 'liga', 'clig', 'calt';
+  -ms-font-feature-settings: 'kern', 'liga', 'clig', 'calt';
+  -webkit-font-feature-settings: 'kern', 'liga', 'clig', 'calt';
+  font-feature-settings: 'kern', 'liga', 'clig', 'calt';
 }
 .modal {
-    position: absolute;
-    width: 600px;
-    top: 50%;
-    left: 50%;
-    right: auto;
-    bottom: auto;
-    marginRight: -50%;
-    transform: translate(-50%, -50%);
+  position: absolute;
+  width: 600px;
+  top: 50%;
+  left: 50%;
+  right: auto;
+  bottom: auto;
+  marginright: -50%;
+  transform: translate(-50%, -50%);
 
-    border: 1px solid rgb(204, 204, 204);
-    background: rgb(255, 255, 255);
-    overflow: auto;
-    border-radius: 4px;
-    outline: none;
-    padding: 20px;
-    max-height: 100vh;
-    overflow-y: auto;
-
+  border: 1px solid rgb(204, 204, 204);
+  background: rgb(255, 255, 255);
+  overflow: auto;
+  border-radius: 4px;
+  outline: none;
+  padding: 20px;
+  max-height: 100vh;
+  overflow-y: auto;
 }
 
 @media only screen and (max-width: 666px) {
-    .modal {
-        width: 100%;
-    }
+  .modal {
+    width: 100%;
+  }
 }

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -1,10 +1,10 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import Helmet from 'react-helmet'
-import { StaticQuery, graphql } from 'gatsby'
-import { Link } from 'gatsby'
-import styles from '../styles.module.css'
-import './layout.css'
+import React from 'react';
+import PropTypes from 'prop-types';
+import Helmet from 'react-helmet';
+import { StaticQuery, graphql, Link } from 'gatsby';
+
+import styles from '../styles.module.css';
+import './layout.css';
 
 const Header = () => {
   return (
@@ -17,8 +17,8 @@ const Header = () => {
       <a href="http://blog.jakoblind.no/">Articles</a>
       <Link to="/about">About</Link>
     </div>
-  )
-}
+  );
+};
 
 const Layout = ({ children, title, metaDescription }) => (
   <StaticQuery
@@ -96,10 +96,10 @@ const Layout = ({ children, title, metaDescription }) => (
       </>
     )}
   />
-)
+);
 
 Layout.propTypes = {
   children: PropTypes.node.isRequired,
-}
+};
 
-export default Layout
+export default Layout;

--- a/src/configurator/Diff.js
+++ b/src/configurator/Diff.js
@@ -1,36 +1,33 @@
-const JsDiff = require('diff')
+const JsDiff = require('diff');
 
 export function getDiffAsLineNumber(json1, json2, diffLines) {
   if (!json1 || !json2) {
-    return null
+    return null;
   }
 
-  let diff
+  let diff;
   if (diffLines) {
-    diff = JsDiff.diffLines(json1, json2)
+    diff = JsDiff.diffLines(json1, json2);
   } else {
-    diff = JsDiff.diffJson(json1, json2)
+    diff = JsDiff.diffJson(json1, json2);
   }
 
-  let highlightedLines = ''
-  let currentLineNumber = 0
+  let highlightedLines = '';
+  let currentLineNumber = 0;
   diff.forEach(part => {
     if (part.removed) {
-      return
+      return;
     }
     if (part.added) {
       if (highlightedLines !== '') {
-        highlightedLines = highlightedLines + ','
+        highlightedLines += ',';
       }
 
-      highlightedLines =
-        highlightedLines +
-        (currentLineNumber + 1) +
-        '-' +
-        (part.count + currentLineNumber)
+      highlightedLines = `${highlightedLines +
+        (currentLineNumber + 1)}-${part.count + currentLineNumber}`;
     }
-    currentLineNumber = currentLineNumber + part.count
-  })
+    currentLineNumber += part.count;
+  });
 
-  return highlightedLines
+  return highlightedLines;
 }

--- a/src/configurator/Diff.test.js
+++ b/src/configurator/Diff.test.js
@@ -1,26 +1,26 @@
-import { getDiffAsLineNumber } from './Diff'
+import { getDiffAsLineNumber } from './Diff';
 
 test('equal should return empty string', () => {
   const json1 = {
     a: 'b',
-  }
+  };
   const json2 = {
     a: 'b',
-  }
+  };
 
-  expect(getDiffAsLineNumber(json1, json2)).toBe('')
-})
+  expect(getDiffAsLineNumber(json1, json2)).toBe('');
+});
 
 test('one line diff', () => {
   const json1 = {
     dependencies: { react: '1.2.3' },
-  }
+  };
   const json2 = {
     dependencies: {},
-  }
+  };
 
-  expect(getDiffAsLineNumber(json1, json2)).toBe('2-2')
-})
+  expect(getDiffAsLineNumber(json1, json2)).toBe('2-2');
+});
 
 test('real example with json input', () => {
   const json1 = {
@@ -45,7 +45,7 @@ test('real example with json input', () => {
       'webpack-cli': '^3.1.2',
       'webpack-dev-server': '^3.1.9',
     },
-  }
+  };
   const json2 = {
     name: 'empty-project-react-react-hot-loader',
     version: '1.0.0',
@@ -74,11 +74,11 @@ test('real example with json input', () => {
       '@babel/preset-env': '^7.1.0',
       'webpack-dev-server': '^3.1.9',
     },
-  }
+  };
 
   // the json are canoncialized
-  expect(getDiffAsLineNumber(json1, json2)).toBe('4-5,10-13')
-})
+  expect(getDiffAsLineNumber(json1, json2)).toBe('4-5,10-13');
+});
 
 test('real example with string input', () => {
   const json1 = JSON.stringify(
@@ -107,7 +107,7 @@ test('real example with string input', () => {
     },
     null,
     2
-  )
+  );
 
   const json2 = JSON.stringify(
     {
@@ -141,8 +141,8 @@ test('real example with string input', () => {
     },
     null,
     2
-  )
+  );
 
   // the json are canoncialized
-  expect(getDiffAsLineNumber(json1, json2, true)).toBe('16-17,23-26')
-})
+  expect(getDiffAsLineNumber(json1, json2, true)).toBe('16-17,23-26');
+});

--- a/src/configurator/common-config/linting.js
+++ b/src/configurator/common-config/linting.js
@@ -1,81 +1,81 @@
-import _ from 'lodash'
+import _ from 'lodash';
 
 // this function is more or less copied from https://github.com/eslint/eslint/blob/master/lib/init/config-initializer.js
 function createEsLintRc(answers = { moduleType: 'esm' }) {
-  const DEFAULT_ECMA_VERSION = 2018
-  let config = {
+  const DEFAULT_ECMA_VERSION = 2018;
+  const config = {
     rules: {},
     env: {},
     parserOptions: {},
     extends: [],
-  }
-  config.parserOptions.ecmaVersion = DEFAULT_ECMA_VERSION
-  config.env.es6 = true
+  };
+  config.parserOptions.ecmaVersion = DEFAULT_ECMA_VERSION;
+  config.env.es6 = true;
   config.globals = {
     Atomics: 'readonly',
     SharedArrayBuffer: 'readonly',
-  }
+  };
 
   if (answers.moduleType === 'esm') {
-    config.parserOptions.sourceType = 'module'
+    config.parserOptions.sourceType = 'module';
   } else if (answers.moduleType === 'commonjs') {
-    config.env.commonjs = true
+    config.env.commonjs = true;
   }
   // add in browser and node environments if necessary
   answers.env.forEach(env => {
-    config.env[env] = true
-  })
+    config.env[env] = true;
+  });
 
   if (answers.framework === 'react') {
     config.parserOptions.ecmaFeatures = {
       jsx: true,
-    }
-    config.plugins = ['react']
+    };
+    config.plugins = ['react'];
   } else if (answers.framework === 'vue') {
-    config.plugins = ['vue']
-    config.extends.push('plugin:vue/essential')
+    config.plugins = ['vue'];
+    config.extends.push('plugin:vue/essential');
   }
   if (answers.extends) {
-    config.extends.push(answers.extends)
+    config.extends.push(answers.extends);
   }
-  config.extends.unshift('eslint:recommended')
+  config.extends.unshift('eslint:recommended');
   // normalize extends
   if (config.extends.length === 0) {
-    delete config.extends
+    delete config.extends;
   } else if (config.extends.length === 1) {
-    config.extends = config.extends[0]
+    config.extends = config.extends[0];
   }
-  return JSON.stringify(config, null, 2)
+  return JSON.stringify(config, null, 2);
 }
 
 const eslint = {
   group: 'Linting',
   devDependencies: configItems => ['eslint'],
   files: configItems => {
-    const isReact = _.includes(configItems, 'React')
-    const isVue = _.includes(configItems, 'Vue')
-    const isPrettier = _.includes(configItems, 'Prettier')
+    const isReact = _.includes(configItems, 'React');
+    const isVue = _.includes(configItems, 'Vue');
+    const isPrettier = _.includes(configItems, 'Prettier');
     const esLintAnswers = {
       moduleType: 'esm',
       framework: isReact ? 'react' : isVue ? 'vue' : null,
       env: ['browser'],
       extends: isPrettier ? 'plugin:prettier/recommended' : null,
-    }
-    return { '.eslintrc.json': createEsLintRc(esLintAnswers) }
+    };
+    return { '.eslintrc.json': createEsLintRc(esLintAnswers) };
   },
-}
+};
 
 const prettier = {
   group: 'Linting',
   devDependencies: configItems => {
-    const isESLint = _.includes(configItems, 'ESLint')
+    const isESLint = _.includes(configItems, 'ESLint');
     return _.concat(
       ['prettier'],
       isESLint ? ['eslint-config-prettier', 'eslint-plugin-prettier'] : []
-    )
+    );
   },
-}
+};
 export default {
   eslint,
   prettier,
-}
+};

--- a/src/configurator/configurator-config.js
+++ b/src/configurator/configurator-config.js
@@ -1,2 +1,2 @@
-export { default as webpackConfig } from './webpack-config'
-export { default as parcelConfig } from './parcel-config'
+export { default as webpackConfig } from './webpack-config';
+export { default as parcelConfig } from './parcel-config';

--- a/src/configurator/configurator-webpack-helpers.js
+++ b/src/configurator/configurator-webpack-helpers.js
@@ -1,14 +1,10 @@
-const _ = require('lodash')
+const _ = require('lodash');
 
 export function addPlugin(webpackConfig, plugin) {
   if (!webpackConfig.plugins) {
-    return Object.assign({}, webpackConfig, {
-      plugins: [plugin],
-    })
+    return { ...webpackConfig, plugins: [plugin] };
   }
-  return Object.assign({}, webpackConfig, {
-    plugins: _.concat(webpackConfig.plugins, plugin),
-  })
+  return { ...webpackConfig, plugins: _.concat(webpackConfig.plugins, plugin) };
 }
 
 export function assignModuleRuleAndResolver(
@@ -17,53 +13,55 @@ export function assignModuleRuleAndResolver(
   resolverExts,
   aliases
 ) {
-  const newWebpackConfig = addModuleRule(webpackConfig, rules)
+  const newWebpackConfig = addModuleRule(webpackConfig, rules);
   return resolverExts
     ? addResolverExtensions(newWebpackConfig, resolverExts, aliases)
-    : newWebpackConfig
+    : newWebpackConfig;
 }
 
 export function addModuleRule(webpackConfig, ruleOrRules) {
-  const isManyRules = _.isArray(ruleOrRules)
-  const rules = isManyRules ? ruleOrRules : [ruleOrRules]
+  const isManyRules = _.isArray(ruleOrRules);
+  const rules = isManyRules ? ruleOrRules : [ruleOrRules];
 
   if (!_.has(webpackConfig, 'module.rules')) {
-    return Object.assign({}, webpackConfig, {
+    return {
+      ...webpackConfig,
       module: {
         rules,
       },
-    })
+    };
   }
 
-  const newWebpackConfig = _.cloneDeep(webpackConfig)
-  newWebpackConfig.module.rules = _.union(newWebpackConfig.module.rules, rules)
-  return newWebpackConfig
+  const newWebpackConfig = _.cloneDeep(webpackConfig);
+  newWebpackConfig.module.rules = _.union(newWebpackConfig.module.rules, rules);
+  return newWebpackConfig;
 }
 
 export function addResolverExtensions(webpackConfig, extOrExts, alias) {
-  const isManyExtensions = _.isArray(extOrExts)
-  const extensions = isManyExtensions ? extOrExts : [extOrExts]
+  const isManyExtensions = _.isArray(extOrExts);
+  const extensions = isManyExtensions ? extOrExts : [extOrExts];
 
   if (!_.has(webpackConfig, 'resolve')) {
-    return Object.assign({}, webpackConfig, {
+    return {
+      ...webpackConfig,
       resolve: {
         extensions,
         ...(_.isEmpty(alias) ? {} : { alias }),
       },
-    })
+    };
   }
 
-  const newWebpackConfig = _.cloneDeep(webpackConfig)
+  const newWebpackConfig = _.cloneDeep(webpackConfig);
   newWebpackConfig.resolve.extensions = _.union(
     newWebpackConfig.resolve.extensions,
     extensions
-  )
+  );
 
-  return newWebpackConfig
+  return newWebpackConfig;
 }
 
 export const getStyleLoaderOrVueStyleLoader = configItems =>
-  _.includes(configItems, 'Vue') ? 'vue-style-loader' : 'style-loader'
+  _.includes(configItems, 'Vue') ? 'vue-style-loader' : 'style-loader';
 
 export const getStyleLoaderDependencyIfNeeded = configItems =>
-  _.includes(configItems, 'Vue') ? [] : ['style-loader']
+  _.includes(configItems, 'Vue') ? [] : ['style-loader'];

--- a/src/configurator/configurator.js
+++ b/src/configurator/configurator.js
@@ -1,46 +1,50 @@
-import jsStringify from 'javascript-stringify'
-import _ from 'lodash'
+import jsStringify from 'javascript-stringify';
+import _ from 'lodash';
 
-import { baseWebpack, baseWebpackImports, packageJson } from '../templates/base'
-import { webpackConfig } from './configurator-config'
+import {
+  baseWebpack,
+  baseWebpackImports,
+  packageJson,
+} from '../templates/base';
+import { webpackConfig } from './configurator-config';
 
-const features = webpackConfig.features // TODO it should not be read from here
+const { features } = webpackConfig; // TODO it should not be read from here
 
 export function getDefaultProjectName(name, features) {
-  return name + '-' + _.kebabCase(_.sortBy(features))
+  return `${name}-${_.kebabCase(_.sortBy(features))}`;
 }
 
 function stringifyReplacer(value, indent, stringify) {
   if (typeof value === 'string' && value.startsWith('CODE:')) {
-    return value.replace(/"/g, '\\"').replace(/^CODE:/, '')
+    return value.replace(/"/g, '\\"').replace(/^CODE:/, '');
   }
 
-  return stringify(value)
+  return stringify(value);
 }
 
 function createConfig(configItems, configType) {
-  const isReact = _.includes(configItems, 'React')
-  const isTypescript = _.includes(configItems, 'Typescript')
-  const isHotReact = _.includes(configItems, 'React hot loader')
+  const isReact = _.includes(configItems, 'React');
+  const isTypescript = _.includes(configItems, 'Typescript');
+  const isHotReact = _.includes(configItems, 'React hot loader');
 
-  let entryExtension = 'js'
+  let entryExtension = 'js';
   if (isTypescript) {
     if (isReact) {
-      entryExtension = 'tsx'
+      entryExtension = 'tsx';
     } else {
-      entryExtension = 'ts'
+      entryExtension = 'ts';
     }
   }
 
-  let entry = `./src/index.${entryExtension}`
+  let entry = `./src/index.${entryExtension}`;
   if (isHotReact) {
     entry = [
       'react-hot-loader/patch', // activate HMR for React
       `./src/index.${entryExtension}`,
-    ]
+    ];
   }
-  const baseWebpackTsSupport = _.assignIn(baseWebpack, { entry })
-  const base = configType === 'webpack' ? baseWebpackTsSupport : {}
+  const baseWebpackTsSupport = _.assignIn(baseWebpack, { entry });
+  const base = configType === 'webpack' ? baseWebpackTsSupport : {};
   return jsStringify(
     _.reduce(
       configItems,
@@ -50,7 +54,7 @@ function createConfig(configItems, configType) {
     ),
     stringifyReplacer,
     2
-  )
+  );
 }
 
 export function getNpmDependencies(featureConfig, configItems) {
@@ -59,51 +63,50 @@ export function getNpmDependencies(featureConfig, configItems) {
       (acc, currentValue) =>
         _.concat(
           acc,
-          featureConfig.features[currentValue]['dependencies'](configItems)
+          featureConfig.features[currentValue].dependencies(configItems)
         ),
       _.get(featureConfig, 'base.dependencies', [])
     )
     .uniq()
-    .value()
+    .value();
 
   const devDependencies = _.chain(configItems)
     .reduce(
       (acc, currentValue) =>
         _.concat(
           acc,
-          featureConfig.features[currentValue]['devDependencies'](configItems)
+          featureConfig.features[currentValue].devDependencies(configItems)
         ),
       _.get(featureConfig, 'base.devDependencies', [])
     )
     .uniq()
-    .value()
+    .value();
 
   return {
     dependencies,
     devDependencies,
-  }
+  };
 }
 
 export function getWebpackImports(configItems) {
   return _.reduce(
     configItems,
-    (acc, currentValue) =>
-      _.concat(acc, features[currentValue]['webpackImports']),
+    (acc, currentValue) => _.concat(acc, features[currentValue].webpackImports),
     []
-  )
+  );
 }
 
 export function createBabelConfig(configItems) {
-  const config = createConfig(configItems, 'babel')
-  return config === '{}' ? null : config
+  const config = createConfig(configItems, 'babel');
+  return config === '{}' ? null : config;
 }
 
 function createHotReloadModifier(configItems) {
-  const isCodeSplit = _.includes(configItems, 'Code split vendors')
-  const isHotReact = _.includes(configItems, 'React hot loader')
+  const isCodeSplit = _.includes(configItems, 'Code split vendors');
+  const isHotReact = _.includes(configItems, 'React hot loader');
 
   if (!isCodeSplit || !isHotReact) {
-    return null
+    return null;
   }
 
   // More info here: https://stackoverflow.com/a/50217641
@@ -111,32 +114,32 @@ function createHotReloadModifier(configItems) {
     // Cannot use 'contenthash' when hot reloading is enabled.
     config.output.filename = '[name].[hash].js';
   }
-`
+`;
 }
 
 function createWebpackConfigExportStatement(configItems) {
-  const hotReloadModifier = createHotReloadModifier(configItems)
+  const hotReloadModifier = createHotReloadModifier(configItems);
   if (!hotReloadModifier) {
-    return `config`
+    return `config`;
   }
 
   return `(env, argv) => {
   ${hotReloadModifier}
   return config;
-}`
+}`;
 }
 
 export function createWebpackConfig(configItems) {
-  const imports = _.concat(baseWebpackImports, getWebpackImports(configItems))
-  const importsLines = imports.join('\n')
-  const config = createConfig(configItems, 'webpack')
-  const exportStatement = createWebpackConfigExportStatement(configItems)
+  const imports = _.concat(baseWebpackImports, getWebpackImports(configItems));
+  const importsLines = imports.join('\n');
+  const config = createConfig(configItems, 'webpack');
+  const exportStatement = createWebpackConfigExportStatement(configItems);
 
   return `${importsLines}
 
 const config = ${config};
 
-module.exports = ${exportStatement};`
+module.exports = ${exportStatement};`;
 }
 
 // some config items can alter the package json. for example the scripts section
@@ -144,19 +147,19 @@ function createPackageJsonConfig(featureConfig, configItems) {
   return _.reduce(
     configItems,
     (acc, currentValue) =>
-      _.merge(acc, featureConfig.features[currentValue]['packageJson']),
+      _.merge(acc, featureConfig.features[currentValue].packageJson),
     {}
-  )
+  );
 }
 // some config items can alter the package json. for example the scripts section
 export function createAdditionalFilesMap(featureConfig, configItems) {
   const filesFromFeatures = _.reduce(
     configItems,
     (acc, currentValue) =>
-      _.assign(acc, featureConfig.features[currentValue]['files'](configItems)),
+      _.assign(acc, featureConfig.features[currentValue].files(configItems)),
     {}
-  )
-  return _.assign(filesFromFeatures, featureConfig.base.files(configItems))
+  );
+  return _.assign(filesFromFeatures, featureConfig.base.files(configItems));
 }
 
 export function getPackageJson(
@@ -168,42 +171,41 @@ export function getPackageJson(
   const {
     dependencies: dependenciesNames,
     devDependencies: devDependenciesNames,
-  } = getNpmDependencies(featureConfig, features)
+  } = getNpmDependencies(featureConfig, features);
 
   const dependenciesVersionsPromises = _.map(
     dependenciesNames,
     getNodeVersionPromise
-  )
+  );
   const devDependenciesVersionsPromises = _.map(
     devDependenciesNames,
     getNodeVersionPromise
-  )
-  let dependenciesVersions
+  );
+  let dependenciesVersions;
   return Promise.all(dependenciesVersionsPromises)
     .then(response => {
-      dependenciesVersions = response
-      return Promise.all(devDependenciesVersionsPromises)
+      dependenciesVersions = response;
+      return Promise.all(devDependenciesVersionsPromises);
     })
     .then(devDependenciesVersions => {
-      const dependencies = _.zipObject(dependenciesNames, dependenciesVersions)
+      const dependencies = _.zipObject(dependenciesNames, dependenciesVersions);
       const devDependencies = _.zipObject(
         devDependenciesNames,
         devDependenciesVersions
-      )
+      );
 
-      const generatedPackageJson = Object.assign(
-        {},
-        { name },
-        _.merge(
+      const generatedPackageJson = {
+        name,
+        ..._.merge(
           {},
           packageJson,
           featureConfig.base.packageJson,
           createPackageJsonConfig(featureConfig, features)
         ),
-        { dependencies },
-        { devDependencies }
-      )
+        dependencies,
+        devDependencies,
+      };
 
-      return generatedPackageJson
-    })
+      return generatedPackageJson;
+    });
 }

--- a/src/configurator/configurator.test.js
+++ b/src/configurator/configurator.test.js
@@ -1,39 +1,43 @@
-import { createWebpackConfig } from './configurator'
+import { createWebpackConfig } from './configurator';
 
 describe('Hot reload and Code split vs. `contenthash` in output filename', () => {
-  const staticFilename = `filename: 'bundle.js'`
-  const hashedFilename = `filename: '[name].[contenthash].js'`
-  const modifiedFilename = '[name].[hash].js'
-  const featureReact = 'React'
-  const featureHot = 'React hot loader'
-  const featureSplit = 'Code split vendors'
+  const staticFilename = `filename: 'bundle.js'`;
+  const hashedFilename = `filename: '[name].[contenthash].js'`;
+  const modifiedFilename = '[name].[hash].js';
+  const featureReact = 'React';
+  const featureHot = 'React hot loader';
+  const featureSplit = 'Code split vendors';
 
   test('static filename without Hot Reload and Code Split', () => {
-    const result = createWebpackConfig([featureReact])
+    const result = createWebpackConfig([featureReact]);
 
-    expect(result).toContain(staticFilename)
-    expect(result).not.toContain(hashedFilename)
-    expect(result).not.toContain(modifiedFilename)
-  })
+    expect(result).toContain(staticFilename);
+    expect(result).not.toContain(hashedFilename);
+    expect(result).not.toContain(modifiedFilename);
+  });
   test('static filename when Hot Reload enabled', () => {
-    const result = createWebpackConfig([featureReact, featureHot])
+    const result = createWebpackConfig([featureReact, featureHot]);
 
-    expect(result).toContain(staticFilename)
-    expect(result).not.toContain(hashedFilename)
-    expect(result).not.toContain(modifiedFilename)
-  })
+    expect(result).toContain(staticFilename);
+    expect(result).not.toContain(hashedFilename);
+    expect(result).not.toContain(modifiedFilename);
+  });
   test('hashed filename when Code Split enabled', () => {
-    const result = createWebpackConfig([featureReact, featureSplit])
+    const result = createWebpackConfig([featureReact, featureSplit]);
 
-    expect(result).not.toContain(staticFilename)
-    expect(result).toContain(hashedFilename)
-    expect(result).not.toContain(modifiedFilename)
-  })
+    expect(result).not.toContain(staticFilename);
+    expect(result).toContain(hashedFilename);
+    expect(result).not.toContain(modifiedFilename);
+  });
   test('hot version of hashed filename when Hot Reload and Code Split enabled', () => {
-    const result = createWebpackConfig([featureReact, featureHot, featureSplit])
+    const result = createWebpackConfig([
+      featureReact,
+      featureHot,
+      featureSplit,
+    ]);
 
-    expect(result).not.toContain(staticFilename)
-    expect(result).toContain(hashedFilename)
-    expect(result).toContain(modifiedFilename)
-  })
-})
+    expect(result).not.toContain(staticFilename);
+    expect(result).toContain(hashedFilename);
+    expect(result).toContain(modifiedFilename);
+  });
+});

--- a/src/configurator/parcel-config/index.js
+++ b/src/configurator/parcel-config/index.js
@@ -1,26 +1,26 @@
-import _ from 'lodash'
+import _ from 'lodash';
 
-import { css, scss, less, stylus } from '../../templates/styling'
-import { reactIndexJs, reactIndexTsx } from '../../templates/react/index'
-import { indexHtml } from '../../templates/base'
-import { emptyIndexJs } from '../../templates/empty/index'
-import { tsconfig, tsconfigReact } from '../../templates/ts'
-import { vueIndexAppVue, vueIndexTs, vueShimType } from '../../templates/vue'
+import { css, scss, less, stylus } from '../../templates/styling';
+import { reactIndexJs, reactIndexTsx } from '../../templates/react/index';
+import { indexHtml } from '../../templates/base';
+import { emptyIndexJs } from '../../templates/empty/index';
+import { tsconfig, tsconfigReact } from '../../templates/ts';
+import { vueIndexAppVue, vueIndexTs, vueShimType } from '../../templates/vue';
 
-import lintingRules from '../common-config/linting'
+import lintingRules from '../common-config/linting';
 
 function getStyleImports(configItems) {
-  const isCss = _.includes(configItems, 'CSS')
-  const isSass = _.includes(configItems, 'Sass')
-  const isLess = _.includes(configItems, 'Less')
-  const isStylus = _.includes(configItems, 'stylus')
+  const isCss = _.includes(configItems, 'CSS');
+  const isSass = _.includes(configItems, 'Sass');
+  const isLess = _.includes(configItems, 'Less');
+  const isStylus = _.includes(configItems, 'stylus');
   return _.concat(
     [],
     isCss ? [`import "./styles.css";`] : [],
     isSass ? [`import "./styles.scss";`] : [],
     isLess ? [`import "./styles.less";`] : [],
     isStylus ? [`import "./styles.styl";`] : []
-  )
+  );
 }
 export default (() => {
   const features = {
@@ -28,58 +28,57 @@ export default (() => {
       group: 'Main library',
       dependencies: configItems => ['react', 'react-dom'],
       devDependencies: configItems => {
-        const isTypescript = _.includes(configItems, 'Typescript')
+        const isTypescript = _.includes(configItems, 'Typescript');
         return _.concat(
           [],
           isTypescript ? ['@types/react', '@types/react-dom'] : []
-        )
+        );
       },
       files: configItems => {
-        const isTypescript = _.includes(configItems, 'Typescript')
-        const extraImports = getStyleImports(configItems)
+        const isTypescript = _.includes(configItems, 'Typescript');
+        const extraImports = getStyleImports(configItems);
 
         if (isTypescript) {
           return {
             'src/index.tsx': reactIndexTsx(extraImports),
             'src/index.html': indexHtml('index.tsx'),
-          }
-        } else {
-          return {
-            'src/index.js': reactIndexJs(extraImports),
-            'src/index.html': indexHtml('index.js'),
-          }
+          };
         }
+        return {
+          'src/index.js': reactIndexJs(extraImports),
+          'src/index.html': indexHtml('index.js'),
+        };
       },
     },
     Vue: {
       group: 'Main library',
       dependencies: configItems => ['vue'],
       files: configItems => {
-        const isTypescript = _.includes(configItems, 'Typescript')
-        const indexExtension = isTypescript ? 'ts' : 'js'
-        const isCss = _.includes(configItems, 'CSS')
-        const isLess = _.includes(configItems, 'Less')
-        const isSass = _.includes(configItems, 'Sass')
-        const isStylus = _.includes(configItems, 'stylus')
+        const isTypescript = _.includes(configItems, 'Typescript');
+        const indexExtension = isTypescript ? 'ts' : 'js';
+        const isCss = _.includes(configItems, 'CSS');
+        const isLess = _.includes(configItems, 'Less');
+        const isSass = _.includes(configItems, 'Sass');
+        const isStylus = _.includes(configItems, 'stylus');
         const cssStyle = `<style>
 ${css}
-</style>`
+</style>`;
         const lessStyle = `<style lang="less">
 ${less}
-</style>`
+</style>`;
         const sassStyle = `<style lang="scss">
 ${scss}
-</style>`
+</style>`;
         const stylusStyle = `<style lang="styl">
 ${stylus}
-</style>`
+</style>`;
         const styling = _.concat(
           [],
           isCss ? cssStyle : [],
           isSass ? sassStyle : [],
           isLess ? lessStyle : [],
           isStylus ? stylusStyle : []
-        )
+        );
 
         return _.assign(
           {
@@ -88,19 +87,19 @@ ${stylus}
             [`src/index.${indexExtension}`]: vueIndexTs(),
           },
           isTypescript ? { 'vue-shim.d.ts': vueShimType } : {}
-        )
+        );
       },
     },
 
     Babel: {
       group: 'Transpiler',
-      babel: (babelConfig, configItems) =>
-        Object.assign({}, babelConfig, {
-          presets: _.concat(
-            [['@babel/preset-env', { modules: false }]],
-            _.includes(configItems, 'React') ? '@babel/preset-react' : []
-          ),
-        }),
+      babel: (babelConfig, configItems) => ({
+        ...babelConfig,
+        presets: _.concat(
+          [['@babel/preset-env', { modules: false }]],
+          _.includes(configItems, 'React') ? '@babel/preset-react' : []
+        ),
+      }),
       devDependencies: configItems =>
         _.concat(
           ['@babel/core', '@babel/preset-env'],
@@ -110,20 +109,20 @@ ${stylus}
     Typescript: {
       group: 'Transpiler',
       files: configItems => {
-        const isReact = _.includes(configItems, 'React')
-        const isVue = _.includes(configItems, 'Vue')
+        const isReact = _.includes(configItems, 'React');
+        const isVue = _.includes(configItems, 'Vue');
 
         const configFiles = isReact
           ? { 'tsconfig.json': tsconfigReact }
-          : { 'tsconfig.json': tsconfig }
+          : { 'tsconfig.json': tsconfig };
         const sourceFiles =
           !isReact && !isVue
             ? {
                 'src/index.html': indexHtml('index.ts'),
                 'src/index.ts': emptyIndexJs(),
               }
-            : {}
-        return _.assign(configFiles, sourceFiles)
+            : {};
+        return _.assign(configFiles, sourceFiles);
       },
     },
     CSS: {
@@ -132,7 +131,7 @@ ${stylus}
     },
     Sass: {
       group: 'Styling',
-      //devDependencies: configItems => ['sass'],//ToDO is thiss needed?
+      // devDependencies: configItems => ['sass'],//ToDO is thiss needed?
       files: configItems => ({ 'src/styles.scss': scss }),
     },
     Less: {
@@ -145,26 +144,26 @@ ${stylus}
     },
     ESLint: lintingRules.eslint,
     Prettier: lintingRules.prettier,
-  }
+  };
   const featuresNoNulls = _.mapValues(features, item => {
     if (!item.babel) {
-      item.babel = _.identity
+      item.babel = _.identity;
     }
     if (!item.dependencies) {
-      item.dependencies = () => []
+      item.dependencies = () => [];
     }
     if (!item.devDependencies) {
-      item.devDependencies = () => []
+      item.devDependencies = () => [];
     }
     if (!item.packageJson) {
-      item.packageJson = {}
+      item.packageJson = {};
     }
     if (!item.files) {
-      item.files = () => {}
+      item.files = () => {};
     }
 
-    return item
-  })
+    return item;
+  });
   return {
     features: featuresNoNulls,
     base: {
@@ -176,18 +175,17 @@ ${stylus}
       },
       devDependencies: ['parcel-bundler'],
       files: configItems => {
-        const isReact = _.includes(configItems, 'React')
-        const isTypescript = _.includes(configItems, 'Typescript')
-        const isVue = _.includes(configItems, 'Vue')
+        const isReact = _.includes(configItems, 'React');
+        const isTypescript = _.includes(configItems, 'Typescript');
+        const isVue = _.includes(configItems, 'Vue');
         if (!isReact && !isTypescript && !isVue) {
           return {
             'src/index.js': emptyIndexJs(getStyleImports(configItems)),
             'src/index.html': indexHtml('index.js'),
-          }
-        } else {
-          return []
+          };
         }
+        return [];
       },
     },
-  }
-})()
+  };
+})();

--- a/src/configurator/project-generator.js
+++ b/src/configurator/project-generator.js
@@ -1,6 +1,6 @@
-import _ from 'lodash'
+import _ from 'lodash';
 
-import { readmeFile, readmeFileParcel } from '../templates/base'
+import { readmeFile, readmeFileParcel } from '../templates/base';
 
 import {
   createWebpackConfig,
@@ -8,9 +8,9 @@ import {
   getDefaultProjectName,
   getPackageJson,
   createAdditionalFilesMap,
-} from './configurator'
+} from './configurator';
 
-import { parcelConfig, webpackConfig } from './configurator-config'
+import { parcelConfig, webpackConfig } from './configurator-config';
 
 /*
   this function will call an external API to get version for node
@@ -20,18 +20,18 @@ import { parcelConfig, webpackConfig } from './configurator-config'
 
 */
 const generateProject = (features, name, getNodeVersionPromise) => {
-  const isBabel = _.includes(features, 'Babel')
-  const isReact = _.includes(features, 'React')
-  const isHotReact = _.includes(features, 'React hot loader')
-  const additionalFilesMap = createAdditionalFilesMap(webpackConfig, features)
-  const newWebpackConfig = createWebpackConfig(features)
-  const newBabelConfig = createBabelConfig(features)
-  const projectName = name || getDefaultProjectName('empty-project', features)
+  const isBabel = _.includes(features, 'Babel');
+  const isReact = _.includes(features, 'React');
+  const isHotReact = _.includes(features, 'React hot loader');
+  const additionalFilesMap = createAdditionalFilesMap(webpackConfig, features);
+  const newWebpackConfig = createWebpackConfig(features);
+  const newBabelConfig = createBabelConfig(features);
+  const projectName = name || getDefaultProjectName('empty-project', features);
 
   const maybeConfigBabel =
     newBabelConfig && (isReact || isBabel)
       ? { '.babelrc': newBabelConfig }
-      : null
+      : null;
 
   const fileMap = _.assign(
     {},
@@ -42,7 +42,7 @@ const generateProject = (features, name, getNodeVersionPromise) => {
     },
     additionalFilesMap,
     maybeConfigBabel
-  )
+  );
 
   if (getNodeVersionPromise) {
     return getPackageJson(
@@ -51,25 +51,24 @@ const generateProject = (features, name, getNodeVersionPromise) => {
       getNodeVersionPromise,
       features
     ).then(packageJson => {
-      fileMap['package.json'] = JSON.stringify(packageJson, null, 2)
-      return fileMap
-    })
-  } else {
-    return fileMap
+      fileMap['package.json'] = JSON.stringify(packageJson, null, 2);
+      return fileMap;
+    });
   }
-}
+  return fileMap;
+};
 
 export function generateParcelProject(features, name, getNodeVersionPromise) {
-  const isBabel = _.includes(features, 'Babel')
-  const isReact = _.includes(features, 'React')
-  const isTypescript = _.includes(features, 'Typescript')
-  const newBabelConfig = createBabelConfig(features)
-  const additionalFilesMap = createAdditionalFilesMap(parcelConfig, features)
-  const projectName = name || getDefaultProjectName('empty-project', features)
+  const isBabel = _.includes(features, 'Babel');
+  const isReact = _.includes(features, 'React');
+  const isTypescript = _.includes(features, 'Typescript');
+  const newBabelConfig = createBabelConfig(features);
+  const additionalFilesMap = createAdditionalFilesMap(parcelConfig, features);
+  const projectName = name || getDefaultProjectName('empty-project', features);
   const maybeConfigBabel =
     newBabelConfig && (isReact || isBabel)
       ? { '.babelrc': newBabelConfig }
-      : null
+      : null;
 
   const fileMap = _.assign(
     {},
@@ -78,7 +77,7 @@ export function generateParcelProject(features, name, getNodeVersionPromise) {
     },
     maybeConfigBabel,
     additionalFilesMap
-  )
+  );
 
   // TODO there is some duplicated code here. sorry
   if (getNodeVersionPromise) {
@@ -88,12 +87,11 @@ export function generateParcelProject(features, name, getNodeVersionPromise) {
       getNodeVersionPromise,
       features
     ).then(packageJson => {
-      fileMap['package.json'] = JSON.stringify(packageJson, null, 2)
-      return fileMap
-    })
-  } else {
-    return fileMap
+      fileMap['package.json'] = JSON.stringify(packageJson, null, 2);
+      return fileMap;
+    });
   }
+  return fileMap;
 }
 
-export default generateProject
+export default generateProject;

--- a/src/configurator/project-generator.test.js
+++ b/src/configurator/project-generator.test.js
@@ -1,27 +1,27 @@
-import projectGenerator from './project-generator'
-import _ from 'lodash'
+import _ from 'lodash';
+import projectGenerator from './project-generator';
 
 test('React project', () => {
-  const project = projectGenerator(['React'])
+  const project = projectGenerator(['React']);
 
-  expect(project['.babelrc']).not.toBeNull()
-  expect(_.size(project)).toBe(6)
-})
+  expect(project['.babelrc']).not.toBeNull();
+  expect(_.size(project)).toBe(6);
+});
 
 test('Vue project', () => {
-  const project = projectGenerator(['Vue'])
+  const project = projectGenerator(['Vue']);
 
-  expect(project['src/App.vue']).toBeDefined()
-  expect(_.size(project)).toBe(6)
+  expect(project['src/App.vue']).toBeDefined();
+  expect(_.size(project)).toBe(6);
 
-  const projectWithTypescript = projectGenerator(['Vue', 'Typescript'])
+  const projectWithTypescript = projectGenerator(['Vue', 'Typescript']);
 
-  expect(projectWithTypescript['vue-shim.d.ts']).toBeDefined()
-  expect(_.size(projectWithTypescript)).toBe(8)
-})
+  expect(projectWithTypescript['vue-shim.d.ts']).toBeDefined();
+  expect(_.size(projectWithTypescript)).toBe(8);
+});
 
 test('Empty project', () => {
-  const project = projectGenerator([])
+  const project = projectGenerator([]);
 
-  expect(_.size(project)).toBe(5)
-})
+  expect(_.size(project)).toBe(5);
+});

--- a/src/configurator/webpack-config/index.js
+++ b/src/configurator/webpack-config/index.js
@@ -1,38 +1,38 @@
-import _ from 'lodash'
+import _ from 'lodash';
 import {
   reactIndexJs,
   reactIndexTsx,
   reactAppJs,
   reactAppTsx,
-} from '../../templates/react/index'
+} from '../../templates/react/index';
 
 import {
   addPlugin,
   assignModuleRuleAndResolver,
   addModuleRule,
-} from '../configurator-webpack-helpers'
-import { vueIndexAppVue, vueIndexTs, vueShimType } from '../../templates/vue'
-import { indexHtml } from '../../templates/base'
-import { emptyIndexJs } from '../../templates/empty/index'
+} from '../configurator-webpack-helpers';
+import { vueIndexAppVue, vueIndexTs, vueShimType } from '../../templates/vue';
+import { indexHtml } from '../../templates/base';
+import { emptyIndexJs } from '../../templates/empty/index';
 
-import { tsconfig, tsconfigReact } from '../../templates/ts'
+import { tsconfig, tsconfigReact } from '../../templates/ts';
 
-import { css, scss, less, stylus } from '../../templates/styling'
-import stylingRules from './stylingRules'
-import lintingRules from '../common-config/linting'
+import { css, scss, less, stylus } from '../../templates/styling';
+import stylingRules from './stylingRules';
+import lintingRules from '../common-config/linting';
 
 function getStyleImports(configItems) {
-  const isCss = _.includes(configItems, 'CSS')
-  const isSass = _.includes(configItems, 'Sass')
-  const isLess = _.includes(configItems, 'Less')
-  const isStylus = _.includes(configItems, 'stylus')
+  const isCss = _.includes(configItems, 'CSS');
+  const isSass = _.includes(configItems, 'Sass');
+  const isLess = _.includes(configItems, 'Less');
+  const isStylus = _.includes(configItems, 'stylus');
   return _.concat(
     [],
     isCss ? [`import "./styles.css";`] : [],
     isSass ? [`import "./styles.scss";`] : [],
     isLess ? [`import "./styles.less";`] : [],
     isStylus ? [`import "./styles.styl";`] : []
-  )
+  );
 }
 export default (() => {
   const features = {
@@ -40,31 +40,30 @@ export default (() => {
       group: 'Main library',
       dependencies: configItems => ['react', 'react-dom'],
       devDependencies: configItems => {
-        const isTypescript = _.includes(configItems, 'Typescript')
-        const isBabel = _.includes(configItems, 'Babel')
+        const isTypescript = _.includes(configItems, 'Typescript');
+        const isBabel = _.includes(configItems, 'Babel');
         return _.concat(
           [],
           isTypescript ? ['@types/react', '@types/react-dom'] : [],
           isBabel ? ['@babel/preset-react'] : []
-        )
+        );
       },
       files: configItems => {
-        const isTypescript = _.includes(configItems, 'Typescript')
-        const isHotReact = _.includes(configItems, 'React hot loader') // Bug fix: Should check on configItems
-        const extraImports = getStyleImports(configItems)
+        const isTypescript = _.includes(configItems, 'Typescript');
+        const isHotReact = _.includes(configItems, 'React hot loader'); // Bug fix: Should check on configItems
+        const extraImports = getStyleImports(configItems);
         if (isTypescript) {
           return {
             'src/app.tsx': reactAppTsx(isHotReact),
             'src/index.tsx': reactIndexTsx(extraImports, isHotReact),
             'dist/index.html': indexHtml(),
-          }
-        } else {
-          return {
-            'src/app.js': reactAppJs(isHotReact),
-            'src/index.js': reactIndexJs(extraImports),
-            'dist/index.html': indexHtml(),
-          }
+          };
         }
+        return {
+          'src/app.js': reactAppJs(isHotReact),
+          'src/index.js': reactIndexJs(extraImports),
+          'dist/index.html': indexHtml(),
+        };
       },
     },
     Vue: {
@@ -82,8 +81,8 @@ export default (() => {
             },
           ],
           ['.js', '.vue']
-        )
-        return addPlugin(webpackConfigWithRule, 'CODE:new VueLoaderPlugin()')
+        );
+        return addPlugin(webpackConfigWithRule, 'CODE:new VueLoaderPlugin()');
       },
       devDependencies: configItems => [
         'vue-loader',
@@ -94,31 +93,31 @@ export default (() => {
       ],
       dependencies: configItems => ['vue'],
       files: configItems => {
-        const isTypescript = _.includes(configItems, 'Typescript')
-        const indexFilename = isTypescript ? 'src/index.ts' : 'src/index.js'
-        const isCss = _.includes(configItems, 'CSS')
-        const isLess = _.includes(configItems, 'Less')
-        const isSass = _.includes(configItems, 'Sass')
-        const isStylus = _.includes(configItems, 'stylus')
+        const isTypescript = _.includes(configItems, 'Typescript');
+        const indexFilename = isTypescript ? 'src/index.ts' : 'src/index.js';
+        const isCss = _.includes(configItems, 'CSS');
+        const isLess = _.includes(configItems, 'Less');
+        const isSass = _.includes(configItems, 'Sass');
+        const isStylus = _.includes(configItems, 'stylus');
         const cssStyle = `<style>
 ${css}
-</style>`
+</style>`;
         const lessStyle = `<style lang="less">
 ${less}
-</style>`
+</style>`;
         const sassStyle = `<style lang="scss">
 ${scss}
-</style>`
+</style>`;
         const stylusStyle = `<style lang="styl">
 ${stylus}
-</style>`
+</style>`;
         const styling = _.concat(
           [],
           isCss ? cssStyle : [],
           isSass ? sassStyle : [],
           isLess ? lessStyle : [],
           isStylus ? stylusStyle : []
-        )
+        );
 
         return _.assign(
           {
@@ -127,23 +126,23 @@ ${stylus}
             [indexFilename]: vueIndexTs(),
           },
           isTypescript ? { 'vue-shim.d.ts': vueShimType } : {}
-        )
+        );
       },
     },
     Babel: {
       group: 'Transpiler',
-      babel: (babelConfig, configItems) =>
-        Object.assign({}, babelConfig, {
-          presets: _.concat(
-            [['@babel/preset-env', { modules: false }]],
-            _.includes(configItems, 'React') ? '@babel/preset-react' : []
-          ),
-        }),
+      babel: (babelConfig, configItems) => ({
+        ...babelConfig,
+        presets: _.concat(
+          [['@babel/preset-env', { modules: false }]],
+          _.includes(configItems, 'React') ? '@babel/preset-react' : []
+        ),
+      }),
       devDependencies: configItems => {
-        const devDepList = ['babel-loader', '@babel/core', '@babel/preset-env']
+        const devDepList = ['babel-loader', '@babel/core', '@babel/preset-env'];
         if (_.includes(configItems, 'React hot loader'))
-          devDepList.push('@hot-loader/react-dom')
-        return devDepList
+          devDepList.push('@hot-loader/react-dom');
+        return devDepList;
       },
       webpack: (webpackConfig, configItems) =>
         assignModuleRuleAndResolver(
@@ -164,50 +163,50 @@ ${stylus}
     Typescript: {
       group: 'Transpiler',
       devDependencies: configItems => {
-        const devDepList = ['typescript', 'awesome-typescript-loader']
+        const devDepList = ['typescript', 'awesome-typescript-loader'];
         if (_.includes(configItems, 'React hot loader'))
-          devDepList.push('@hot-loader/react-dom')
-        return devDepList
+          devDepList.push('@hot-loader/react-dom');
+        return devDepList;
       },
       webpack: (webpackConfig, configItems) => {
-        const isVue = _.includes(configItems, 'Vue')
+        const isVue = _.includes(configItems, 'Vue');
         const typescriptModule = {
           test: /\.ts(x)?$/,
           use: ['awesome-typescript-loader'],
           exclude: /node_modules/,
-        }
+        };
         if (isVue) {
           typescriptModule.options = {
             appendTsSuffixTo: [/\.vue$/],
-          }
+          };
         }
-        const aliases = {}
-        const isHot = _.includes(configItems, 'React hot loader')
+        const aliases = {};
+        const isHot = _.includes(configItems, 'React hot loader');
         if (isHot) {
-          aliases['react-dom'] = '@hot-loader/react-dom'
+          aliases['react-dom'] = '@hot-loader/react-dom';
         }
         return assignModuleRuleAndResolver(
           webpackConfig,
           typescriptModule,
           ['.tsx', '.ts', '.js'],
           aliases
-        )
+        );
       },
       files: configItems => {
-        const isReact = _.includes(configItems, 'React')
-        const isVue = _.includes(configItems, 'Vue')
+        const isReact = _.includes(configItems, 'React');
+        const isVue = _.includes(configItems, 'Vue');
 
         const configFiles = isReact
           ? { 'tsconfig.json': tsconfigReact }
-          : { 'tsconfig.json': tsconfig }
+          : { 'tsconfig.json': tsconfig };
         const sourceFiles =
           !isReact && !isVue
             ? {
                 'dist/index.html': indexHtml(),
                 'src/index.ts': emptyIndexJs(),
               }
-            : {}
-        return _.assign(configFiles, sourceFiles)
+            : {};
+        return _.assign(configFiles, sourceFiles);
       },
     },
     CSS: stylingRules.css,
@@ -280,14 +279,14 @@ ${stylus}
     inject: false,
     appMountId: 'app',
   })`
-        )
+        );
 
         const withFilename = _.setWith(
           _.clone(withPlugin),
           'output.filename',
           '[name].[contenthash].js',
           _.clone
-        )
+        );
         return _.setWith(
           _.clone(withFilename),
           'optimization',
@@ -304,57 +303,55 @@ ${stylus}
             },
           },
           _.clone
-        )
+        );
       },
     },
     'React hot loader': {
       group: 'React',
       babel: (babelConfig, configItems) => {
-        if (!_.includes(configItems, 'Babel')) return {} // We don't need babelrc for typescript
-        return Object.assign({}, babelConfig, {
-          plugins: ['react-hot-loader/babel'],
-        })
+        if (!_.includes(configItems, 'Babel')) return {}; // We don't need babelrc for typescript
+        return { ...babelConfig, plugins: ['react-hot-loader/babel'] };
       },
       dependencies: configItems => ['react-hot-loader'],
       devDependencies: configItems => ['webpack-dev-server'],
-      webpack: webpackConfig =>
-        Object.assign({}, webpackConfig, {
-          devServer: {
-            contentBase: './dist',
-          },
-        }),
+      webpack: webpackConfig => ({
+        ...webpackConfig,
+        devServer: {
+          contentBase: './dist',
+        },
+      }),
       packageJson: {
         scripts: {
           start: 'webpack-dev-server --hot --mode development',
         },
       },
     },
-  }
+  };
   const featuresNoNulls = _.mapValues(features, item => {
     if (!item.babel) {
-      item.babel = _.identity
+      item.babel = _.identity;
     }
     if (!item.webpack) {
-      item.webpack = _.identity
+      item.webpack = _.identity;
     }
     if (!item.webpackImports) {
-      item.webpackImports = []
+      item.webpackImports = [];
     }
     if (!item.dependencies) {
-      item.dependencies = () => []
+      item.dependencies = () => [];
     }
     if (!item.devDependencies) {
-      item.devDependencies = () => []
+      item.devDependencies = () => [];
     }
     if (!item.packageJson) {
-      item.packageJson = {}
+      item.packageJson = {};
     }
     if (!item.files) {
-      item.files = () => {}
+      item.files = () => {};
     }
 
-    return item
-  })
+    return item;
+  });
   return {
     features: featuresNoNulls,
     base: {
@@ -366,19 +363,18 @@ ${stylus}
       },
       devDependencies: ['webpack', 'webpack-cli'],
       files: configItems => {
-        const isReact = _.includes(configItems, 'React')
-        const isVue = _.includes(configItems, 'Vue')
-        const isTypescript = _.includes(configItems, 'Typescript')
-        const extraImports = getStyleImports(configItems)
+        const isReact = _.includes(configItems, 'React');
+        const isVue = _.includes(configItems, 'Vue');
+        const isTypescript = _.includes(configItems, 'Typescript');
+        const extraImports = getStyleImports(configItems);
         if (!isTypescript && !isReact && !isVue) {
           return {
             'src/index.js': emptyIndexJs(extraImports),
             'dist/index.html': indexHtml(),
-          }
-        } else {
-          return []
+          };
         }
+        return [];
       },
     },
-  }
-})()
+  };
+})();

--- a/src/configurator/webpack-config/stylingRules.js
+++ b/src/configurator/webpack-config/stylingRules.js
@@ -1,12 +1,18 @@
-import _ from 'lodash'
+import _ from 'lodash';
 
 import {
   addModuleRule,
   getStyleLoaderOrVueStyleLoader,
   getStyleLoaderDependencyIfNeeded,
-} from '../configurator-webpack-helpers'
+} from '../configurator-webpack-helpers';
 
-import { css, scss, less, stylus, postCssConfig } from '../../templates/styling'
+import {
+  css,
+  scss,
+  less,
+  stylus,
+  postCssConfig,
+} from '../../templates/styling';
 
 function cssRules() {
   return {
@@ -14,7 +20,7 @@ function cssRules() {
     devDependencies: configItems =>
       _.concat(['css-loader'], getStyleLoaderDependencyIfNeeded(configItems)),
     webpack: (webpackConfig, configItems) => {
-      const isPostCss = _.includes(configItems, 'PostCSS')
+      const isPostCss = _.includes(configItems, 'PostCSS');
       const cssLoader = isPostCss
         ? {
             loader: 'css-loader',
@@ -22,27 +28,27 @@ function cssRules() {
               importLoaders: 1,
             },
           }
-        : 'css-loader'
+        : 'css-loader';
       const rule = {
         test: /\.css$/,
         use: _.concat(
           [getStyleLoaderOrVueStyleLoader(configItems), cssLoader],
           isPostCss ? 'postcss-loader' : []
         ),
-      }
+      };
       if (_.includes(configItems, 'CSS Modules')) {
-        rule.exclude = /\.module\.css$/
+        rule.exclude = /\.module\.css$/;
       }
-      return addModuleRule(webpackConfig, rule)
+      return addModuleRule(webpackConfig, rule);
     },
     files: configItems => {
-      const isVue = _.includes(configItems, 'Vue')
+      const isVue = _.includes(configItems, 'Vue');
       if (isVue) {
-        return {}
+        return {};
       }
-      return { 'src/styles.css': css }
+      return { 'src/styles.css': css };
     },
-  }
+  };
 }
 
 function cssModulesRules() {
@@ -51,7 +57,7 @@ function cssModulesRules() {
     devDependencies: configItems =>
       _.concat(['css-loader'], getStyleLoaderDependencyIfNeeded(configItems)),
     webpack: (webpackConfig, configItems) => {
-      const isPostCss = _.includes(configItems, 'PostCSS')
+      const isPostCss = _.includes(configItems, 'PostCSS');
       const rule = {
         test: /\.css$/,
         use: _.concat(
@@ -67,13 +73,13 @@ function cssModulesRules() {
           ],
           isPostCss ? 'postcss-loader' : []
         ),
-      }
+      };
       if (_.includes(configItems, 'CSS')) {
-        rule.include = /\.module\.css$/
+        rule.include = /\.module\.css$/;
       }
-      return addModuleRule(webpackConfig, rule)
+      return addModuleRule(webpackConfig, rule);
     },
-  }
+  };
 }
 
 function sassRules() {
@@ -94,13 +100,13 @@ function sassRules() {
         ],
       }),
     files: configItems => {
-      const isVue = _.includes(configItems, 'Vue')
+      const isVue = _.includes(configItems, 'Vue');
       if (isVue) {
-        return {}
+        return {};
       }
-      return { 'src/styles.scss': scss }
+      return { 'src/styles.scss': scss };
     },
-  }
+  };
 }
 
 function lessRules() {
@@ -121,13 +127,13 @@ function lessRules() {
         ],
       }),
     files: configItems => {
-      const isVue = _.includes(configItems, 'Vue')
+      const isVue = _.includes(configItems, 'Vue');
       if (isVue) {
-        return {}
+        return {};
       }
-      return { 'src/styles.less': less }
+      return { 'src/styles.less': less };
     },
-  }
+  };
 }
 
 function stylusRules() {
@@ -148,13 +154,13 @@ function stylusRules() {
         ],
       }),
     files: configItems => {
-      const isVue = _.includes(configItems, 'Vue')
+      const isVue = _.includes(configItems, 'Vue');
       if (isVue) {
-        return {}
+        return {};
       }
-      return { 'src/styles.styl': stylus }
+      return { 'src/styles.styl': stylus };
     },
-  }
+  };
 }
 
 function postCssRules() {
@@ -162,9 +168,9 @@ function postCssRules() {
     group: 'Styling',
     devDependencies: configItems => ['postcss-loader', 'autoprefixer'],
     files: configItems => {
-      return { 'postcss.config.js': postCssConfig }
+      return { 'postcss.config.js': postCssConfig };
     },
-  }
+  };
 }
 
 export default {
@@ -174,4 +180,4 @@ export default {
   less: lessRules(),
   stylus: stylusRules(),
   postCss: postCssRules(),
-}
+};

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,11 +1,11 @@
-import React from 'react'
-import Layout from '../components/layout'
+import React from 'react';
+import Layout from '../components/layout';
 
 const NotFoundPage = () => (
   <Layout>
     <h1>NOT FOUND</h1>
     <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
   </Layout>
-)
+);
 
-export default NotFoundPage
+export default NotFoundPage;

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -1,6 +1,6 @@
-import React from 'react'
-import styles from '../styles.module.css'
-import Layout from '../components/layout'
+import React from 'react';
+import styles from '../styles.module.css';
+import Layout from '../components/layout';
 
 export default () => {
   return (
@@ -27,5 +27,5 @@ export default () => {
         </a>
       </div>
     </Layout>
-  )
-}
+  );
+};

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,56 +1,55 @@
-import React, { useState, useReducer } from 'react'
-import _ from 'lodash'
-import styles from '../styles.module.css'
-import { Link } from 'gatsby'
-import Modal from 'react-modal'
-import jszip from 'jszip'
-import npmVersionPromise from '../fetch-npm-version'
-import Joyride from 'react-joyride'
+import React, { useState, useReducer } from 'react';
+import _ from 'lodash';
+import { Link } from 'gatsby';
+import Modal from 'react-modal';
+import jszip from 'jszip';
+import Joyride from 'react-joyride';
+import { saveAs } from 'file-saver';
+import styles from '../styles.module.css';
+import npmVersionPromise from '../fetch-npm-version';
 
-import { CourseSignupForm } from '../components/SignupForms'
+import { CourseSignupForm } from '../components/SignupForms';
 
 import {
   webpackConfig,
   parcelConfig,
-} from '../configurator/configurator-config'
+} from '../configurator/configurator-config';
 
 import {
   createBabelConfig,
   getNpmDependencies,
   getDefaultProjectName,
-} from '../configurator/configurator'
+} from '../configurator/configurator';
 
-import FileBrowser from '../components/FileBrowser'
+import FileBrowser from '../components/FileBrowser';
 
-import Layout from '../components/layout'
+import Layout from '../components/layout';
 import Features, {
   selectionRules as allSelectionRules,
-} from '../components/configurator/Features'
+} from '../components/configurator/Features';
 import generateProject, {
   generateParcelProject,
-} from '../configurator/project-generator'
+} from '../configurator/project-generator';
 
-import { saveAs } from 'file-saver'
-import onboardingHelp from '../onboardingHelp'
-import DocsViewer from '../components/DocsViewer'
-import { trackPageView, gaSendEvent } from '../googleAnalytics'
+import onboardingHelp from '../onboardingHelp';
+import DocsViewer from '../components/DocsViewer';
+import { trackPageView, gaSendEvent } from '../googleAnalytics';
 
 const StepByStepArea = ({ features, newBabelConfig, isReact, isWebpack }) => {
   const newNpmConfig = getNpmDependencies(
     isWebpack ? webpackConfig : parcelConfig,
     features
-  )
+  );
 
   const npmInstallCommand = _.isEmpty(newNpmConfig.dependencies)
     ? ''
-    : '\nnpm install ' + newNpmConfig.dependencies.join(' ')
-  const npmCommand =
-    'mkdir myapp\ncd myapp\nnpm init -y\nnpm install --save-dev ' +
-    newNpmConfig.devDependencies.join(' ') +
-    npmInstallCommand
-  const isTypescript = _.includes(features, 'Typescript')
+    : `\nnpm install ${newNpmConfig.dependencies.join(' ')}`;
+  const npmCommand = `mkdir myapp\ncd myapp\nnpm init -y\nnpm install --save-dev ${newNpmConfig.devDependencies.join(
+    ' '
+  )}${npmInstallCommand}`;
+  const isTypescript = _.includes(features, 'Typescript');
 
-  let babelStep = null
+  let babelStep = null;
   if (newBabelConfig) {
     babelStep = (
       <div>
@@ -59,9 +58,9 @@ const StepByStepArea = ({ features, newBabelConfig, isReact, isWebpack }) => {
           generated file
         </li>
       </div>
-    )
+    );
   } else if (isTypescript) {
-    //currently, you cannt use both typescript and babel.
+    // currently, you cannt use both typescript and babel.
     // if typescript is selected you must have a tsconf
     babelStep = (
       <div>
@@ -70,21 +69,21 @@ const StepByStepArea = ({ features, newBabelConfig, isReact, isWebpack }) => {
           generated file
         </li>
       </div>
-    )
+    );
   }
-  let webpackStep = null
+  let webpackStep = null;
   if (isWebpack) {
     webpackStep = (
       <li>
         Create <i>webpack.config.js</i> in the root and copy the contents of the
         generated file
       </li>
-    )
+    );
   }
 
-  let srcFoldersStep = (
+  const srcFoldersStep = (
     <li>Create folders src and dist and create source code files</li>
-  )
+  );
 
   return (
     <div className={styles.rightSection}>
@@ -94,7 +93,7 @@ const StepByStepArea = ({ features, newBabelConfig, isReact, isWebpack }) => {
           <li>Create an NPM project and install dependencies</li>
           <textarea
             aria-label="npm commands to install dependencies"
-            readOnly={true}
+            readOnly
             rows="6"
             cols="50"
             value={npmCommand}
@@ -107,8 +106,8 @@ const StepByStepArea = ({ features, newBabelConfig, isReact, isWebpack }) => {
         <Link to="/webpack-course">Need more detailed instructions?</Link>
       </div>
     </div>
-  )
-}
+  );
+};
 
 function Tabs({ selected, setSelected }) {
   return (
@@ -146,13 +145,13 @@ function Tabs({ selected, setSelected }) {
         </button>
       </nav>
     </div>
-  )
+  );
 }
 
-Modal.setAppElement('#___gatsby')
+Modal.setAppElement('#___gatsby');
 
 function DownloadButton({ url, onClick, filename }) {
-  const [modalOpen, setModalOpen] = useState(false)
+  const [modalOpen, setModalOpen] = useState(false);
   const customStyles = {
     content: {
       top: '50%',
@@ -162,15 +161,15 @@ function DownloadButton({ url, onClick, filename }) {
       marginRight: '-50%',
       transform: 'translate(-50%, -50%)',
     },
-  }
+  };
 
   return (
     <div>
       <button
         className={styles.btn}
         onClick={() => {
-          onClick()
-          setModalOpen(true)
+          onClick();
+          setModalOpen(true);
         }}
         id="download"
       >
@@ -213,7 +212,7 @@ function DownloadButton({ url, onClick, filename }) {
         <CourseSignupForm tags={917914} />
       </Modal>
     </div>
-  )
+  );
 }
 
 const selectionRules = {
@@ -227,7 +226,7 @@ const selectionRules = {
     allSelectionRules.additionalSelectFunctions.addCssIfPostCSS,
     allSelectionRules.additionalSelectFunctions.removeEslintIfTypscript,
   ],
-}
+};
 
 const parcelSelectionRules = {
   stopSelectFunctions: [
@@ -237,7 +236,7 @@ const parcelSelectionRules = {
     allSelectionRules.additionalSelectFunctions.enforceEitherReactOrVue,
     allSelectionRules.additionalSelectFunctions.addBabelIfReact,
   ],
-}
+};
 
 const buildConfigConfig = {
   webpack: {
@@ -266,38 +265,39 @@ const buildConfigConfig = {
       <br key={3} />,
     ],
   },
-}
+};
 
 const initialState = (selectedTab = 'webpack') => ({
   selectedTab,
   selectedFeatures: {},
-})
+});
 
 function reducer(state, action) {
   switch (action.type) {
     case 'setSelectedTab':
       const newAllPossibleFeatures = _.keys(
         buildConfigConfig[action.selectedTab].featureConfig.features
-      )
+      );
 
       const filteredFeatures = _.mapValues(
         state.selectedFeatures,
         (selected, feature) =>
           _.includes(newAllPossibleFeatures, feature) && selected
-      )
+      );
 
       return {
         ...state,
         selectedTab: action.selectedTab,
         selectedFeatures: filteredFeatures,
-      }
+      };
     case 'setSelectedFeatures':
-      const setToSelected = !state.selectedFeatures[action.feature]
-      //logFeatureClickToGa(feature, setToSelected)
+      const setToSelected = !state.selectedFeatures[action.feature];
+      // logFeatureClickToGa(feature, setToSelected)
 
-      const selectedFature = Object.assign({}, state.selectedFeatures, {
+      const selectedFature = {
+        ...state.selectedFeatures,
         [action.feature]: setToSelected,
-      })
+      };
 
       if (
         _.some(
@@ -308,7 +308,7 @@ function reducer(state, action) {
           )
         )
       ) {
-        return state
+        return state;
       }
 
       const newSelected = _.reduce(
@@ -317,11 +317,11 @@ function reducer(state, action) {
         (currentSelectionMap, fn) =>
           fn(currentSelectionMap, action.feature, setToSelected),
         selectedFature
-      )
-      return { ...state, selectedFeatures: newSelected }
+      );
+      return { ...state, selectedFeatures: newSelected };
 
     default:
-      throw new Error()
+      throw new Error();
   }
 }
 
@@ -330,36 +330,39 @@ function trackDownload(selectedTab, selectedFeatures) {
     eventCategory: 'Project download',
     eventAction: selectedTab,
     eventLabel: JSON.stringify(selectedFeatures),
-  })
+  });
 }
 
 function trackHelpClick(eventAction) {
   gaSendEvent({
     eventCategory: 'Help clicked',
     eventAction,
-  })
+  });
 }
 
 function Configurator(props) {
-  const [state, dispatch] = useReducer(reducer, initialState(props.selectedTab))
-  const [hoverFeature, setHoverFeature] = useState({})
+  const [state, dispatch] = useReducer(
+    reducer,
+    initialState(props.selectedTab)
+  );
+  const [hoverFeature, setHoverFeature] = useState({});
 
   const {
     featureConfig,
     projectGeneratorFunction,
     defaultFile,
-  } = buildConfigConfig[state.selectedTab]
+  } = buildConfigConfig[state.selectedTab];
 
   const selectedArray = _.chain(state.selectedFeatures)
     .map((v, k) => (v ? k : null))
     .reject(_.isNull)
-    .value()
+    .value();
 
   function onMouseEnterFeature(feature) {
-    setHoverFeature(feature)
+    setHoverFeature(feature);
   }
   function onMouseLeaveFeature() {
-    setHoverFeature(null)
+    setHoverFeature(null);
   }
 
   function downloadZip() {
@@ -368,32 +371,32 @@ function Configurator(props) {
       'empty-project',
       npmVersionPromise
     ).then(res => {
-      const zip = new jszip()
+      const zip = new jszip();
       _.forEach(res, (content, file) => {
-        zip.file(file, content)
-      })
+        zip.file(file, content);
+      });
 
       zip.generateAsync({ type: 'blob' }).then(function(blob) {
-        saveAs(blob, 'empty-project.zip')
-      })
-    })
+        saveAs(blob, 'empty-project.zip');
+      });
+    });
   }
 
-  const newBabelConfig = createBabelConfig(selectedArray)
+  const newBabelConfig = createBabelConfig(selectedArray);
 
-  const isReact = _.includes(selectedArray, 'React')
-  const isTypescript = _.includes(selectedArray, 'Typescript')
+  const isReact = _.includes(selectedArray, 'React');
+  const isTypescript = _.includes(selectedArray, 'Typescript');
 
-  const projectname = getDefaultProjectName('empty-project', selectedArray)
+  const projectname = getDefaultProjectName('empty-project', selectedArray);
 
-  const showFeatures = _.clone(featureConfig.features)
+  const showFeatures = _.clone(featureConfig.features);
 
   if (!isReact) {
-    delete showFeatures['React hot loader']
+    delete showFeatures['React hot loader'];
   }
 
   if (isTypescript) {
-    delete showFeatures['ESLint']
+    delete showFeatures.ESLint;
   }
 
   return (
@@ -401,11 +404,11 @@ function Configurator(props) {
       <Tabs
         selected={state.selectedTab}
         setSelected={selectedTab => {
-          const newUrl = `/${selectedTab}`
-          trackPageView(newUrl)
-          window.history.replaceState(null, null, newUrl)
+          const newUrl = `/${selectedTab}`;
+          trackPageView(newUrl);
+          window.history.replaceState(null, null, newUrl);
 
-          dispatch({ type: 'setSelectedTab', selectedTab })
+          dispatch({ type: 'setSelectedTab', selectedTab });
         }}
       />
 
@@ -425,8 +428,8 @@ function Configurator(props) {
             <DownloadButton
               filename={`${projectname}.zip`}
               onClick={e => {
-                downloadZip()
-                trackDownload(state.selectedTab, selectedArray)
+                downloadZip();
+                trackDownload(state.selectedTab, selectedArray);
               }}
             />
           </div>
@@ -446,8 +449,8 @@ function Configurator(props) {
             <DownloadButton
               filename={`${projectname}.zip`}
               onClick={e => {
-                downloadZip()
-                trackDownload(state.selectedTab, selectedArray)
+                downloadZip();
+                trackDownload(state.selectedTab, selectedArray);
               }}
             />
           </div>
@@ -467,32 +470,32 @@ function Configurator(props) {
         />
       </div>
     </div>
-  )
+  );
 }
 
 export class App extends React.Component {
   joyrideCallback({ lifecycle, step: { target } }) {
     if (lifecycle === 'tooltip') {
-      trackHelpClick(target)
+      trackHelpClick(target);
     }
   }
 
   render() {
     const {
       pageContext: { selectedTab },
-    } = this.props
+    } = this.props;
 
     return (
       <Layout>
         <Joyride
           steps={onboardingHelp}
-          continuous={true}
+          continuous
           callback={this.joyrideCallback}
         />
         <Configurator selectedTab={selectedTab} />
       </Layout>
-    )
+    );
   }
 }
 
-export default App
+export default App;

--- a/src/pages/parcel-course.js
+++ b/src/pages/parcel-course.js
@@ -1,7 +1,7 @@
-import React from 'react'
-import styles from '../styles.module.css'
-import Layout from '../components/layout'
-import { GenericSignupForm } from '../components/SignupForms'
+import React from 'react';
+import styles from '../styles.module.css';
+import Layout from '../components/layout';
+import { GenericSignupForm } from '../components/SignupForms';
 
 export default () => {
   return (
@@ -17,5 +17,5 @@ export default () => {
         <GenericSignupForm />
       </div>
     </Layout>
-  )
-}
+  );
+};

--- a/src/pages/thank-you-for-signing-up.js
+++ b/src/pages/thank-you-for-signing-up.js
@@ -1,6 +1,6 @@
-import React from 'react'
-import Layout from '../components/layout'
-import styles from '../styles.module.css'
+import React from 'react';
+import Layout from '../components/layout';
+import styles from '../styles.module.css';
 
 function App(props) {
   return (
@@ -10,7 +10,7 @@ function App(props) {
         <p>Good stuff will be delivered straight to your inbox.</p>
       </div>
     </Layout>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/src/pages/webpack-book.js
+++ b/src/pages/webpack-book.js
@@ -1,13 +1,13 @@
-import React from 'react'
-import styles from '../styles.module.css'
-import { SampleChapterSignupForm, withHidden } from '../components/SignupForms'
-import Layout from '../components/layout'
-//import Countdown from 'react-countdown-now'
+import React from 'react';
+import styles from '../styles.module.css';
+import { SampleChapterSignupForm, withHidden } from '../components/SignupForms';
+import Layout from '../components/layout';
+// import Countdown from 'react-countdown-now'
 
 export const HiddenSampleChapterSignupForm = withHidden(
   SampleChapterSignupForm,
   'Get a sample chapter'
-)
+);
 
 const BuyButton = () => (
   <a
@@ -17,9 +17,9 @@ const BuyButton = () => (
   >
     Buy Now for $24
   </a>
-)
+);
 
-/*const renderer = ({ days, hours, minutes, seconds, completed }) => {
+/* const renderer = ({ days, hours, minutes, seconds, completed }) => {
   if (completed) {
     return <span>Time's out</span>
   } else {
@@ -37,7 +37,7 @@ const Discount = () => (
     Discount expires in{' '}
     <Countdown date={new Date('2019-04-12T00:00:00')} renderer={renderer} />
   </div>
-)*/
+) */
 
 export default () => {
   return (
@@ -380,5 +380,5 @@ export default () => {
         </p>
       </div>
     </Layout>
-  )
-}
+  );
+};

--- a/src/pages/webpack-course.js
+++ b/src/pages/webpack-course.js
@@ -1,7 +1,7 @@
-import React from 'react'
-import styles from '../styles.module.css'
-import Layout from '../components/layout'
-import { CourseSignupForm } from '../components/SignupForms'
+import React from 'react';
+import styles from '../styles.module.css';
+import Layout from '../components/layout';
+import { CourseSignupForm } from '../components/SignupForms';
 
 export default () => {
   return (
@@ -31,7 +31,7 @@ export default () => {
         </p>
         <h3>Here is what people are saying about the course: </h3>
         <img
-            alt="webpack email course feedback"
+          alt="webpack email course feedback"
           className={styles.shadow}
           src={require('../../images/email-course-feedback1.png')}
         />
@@ -72,5 +72,5 @@ export default () => {
         <br />
       </div>
     </Layout>
-  )
-}
+  );
+};

--- a/src/templates/base.js
+++ b/src/templates/base.js
@@ -4,12 +4,12 @@ export const baseWebpack = {
     path: "CODE:path.resolve(__dirname, 'dist')",
     filename: 'bundle.js',
   },
-}
+};
 
 export const baseWebpackImports = [
   "const webpack = require('webpack');",
   "const path = require('path');",
-]
+];
 
 export const packageJson = {
   // "name": "empty-project-react-less-png-production-mode",
@@ -22,10 +22,10 @@ export const packageJson = {
   scripts: {
     clean: 'rm dist/bundle.js',
   },
-  //"devDependencies": {
+  // "devDependencies": {
   //    "react": "^16.4.1",
-  //}
-}
+  // }
+};
 
 export const indexHtml = (bundleFilename = 'bundle.js') => `<!DOCTYPE html>
 <html>
@@ -37,7 +37,7 @@ export const indexHtml = (bundleFilename = 'bundle.js') => `<!DOCTYPE html>
         <div id="app"></div>
         <script src="${bundleFilename}"></script>
     </body>
-</html>`
+</html>`;
 
 export const readmeFile = (name, isReact, isHot) => `# ${name}
 
@@ -84,7 +84,7 @@ ${
 ## Credits
 
 Made with [createapp.dev](https://createapp.dev/)
-`
+`;
 
 export const readmeFileParcel = (name, isReact) => `# ${name}
 
@@ -122,4 +122,4 @@ ${
 
 Made with [createapp.dev](https://createapp.dev/)
 
-`
+`;

--- a/src/templates/empty/index.js
+++ b/src/templates/empty/index.js
@@ -1,3 +1,4 @@
-import { joinToString } from '../helperFunctions'
+import { joinToString } from '../helperFunctions';
+
 export const emptyIndexJs = (extraImports = []) =>
-  `${joinToString(extraImports)}console.log("hello world!");`
+  `${joinToString(extraImports)}console.log("hello world!");`;

--- a/src/templates/helperFunctions.js
+++ b/src/templates/helperFunctions.js
@@ -1,4 +1,4 @@
-import _ from 'lodash'
+import _ from 'lodash';
 
 export const joinToString = list =>
-  _.reduce(list, (all, i) => all + i + '\n', '')
+  _.reduce(list, (all, i) => `${all + i}\n`, '');

--- a/src/templates/react/index.js
+++ b/src/templates/react/index.js
@@ -1,4 +1,4 @@
-import { joinToString } from '../helperFunctions'
+import { joinToString } from '../helperFunctions';
 
 export const reactAppJs = isHot => `
 import React from "react";
@@ -11,7 +11,7 @@ class App extends React.Component {
 }
 
 export default ${isHot ? 'hot(App)' : 'App'};
-`
+`;
 
 export const reactIndexJs = (extraImports = []) => `import React from "react";
 import ReactDOM from "react-dom";
@@ -19,7 +19,7 @@ import App from "./app";
 ${joinToString(extraImports)}
 
 var mountNode = document.getElementById("app");
-ReactDOM.render(<App name="Jane" />, mountNode);`
+ReactDOM.render(<App name="Jane" />, mountNode);`;
 
 export const reactAppTsx = isHot => `
 import * as React from 'react';
@@ -36,7 +36,7 @@ class App extends React.Component<Props> {
 }
 
 export default ${isHot ? 'hot(App)' : 'App'};
-`
+`;
 
 export const reactIndexTsx = (
   extraImports = [],
@@ -48,4 +48,4 @@ import App from './app';
 ${joinToString(extraImports)}
 var mountNode = document.getElementById("app");
 ReactDOM.render(<App name="Jane" />, mountNode);
-`
+`;

--- a/src/templates/styling.js
+++ b/src/templates/styling.js
@@ -1,31 +1,31 @@
 export const css = `body {
   color: white;
   background-color: black;
-}`
+}`;
 
 export const scss = `$primary-color: white;
 $bg: black;
 body {
   color: $primary-color;
   background-color: $bg;
-}`
+}`;
 
 export const less = `@primary-color: white;
 @bg: black;
 body {
   color: @primary-color;
   background-color: @bg;
-}`
+}`;
 
 export const stylus = `primary-color = white
 bg = black
 body
   color: primary-color;
   background-color: bg;
-`
+`;
 
 export const postCssConfig = `module.exports = {
   plugins: [
     require('autoprefixer')
   ]
-};`
+};`;

--- a/src/templates/ts/index.js
+++ b/src/templates/ts/index.js
@@ -13,7 +13,7 @@ export const tsconfig = `{
     "include": [
         "./src/**/*"
     ]
-}`
+}`;
 
 export const tsconfigReact = `{
     "compilerOptions": {
@@ -31,7 +31,7 @@ export const tsconfigReact = `{
     "include": [
         "./src/**/*"
     ]
-}`
+}`;
 
 export const indexTypescript = `
 async function helloWorld() {
@@ -41,4 +41,4 @@ async function helloWorld() {
 helloWorld()
   .then((msg) => console.log(msg))
   .catch((e) => console.error(e));
-`
+`;

--- a/src/templates/vue/index.js
+++ b/src/templates/vue/index.js
@@ -1,13 +1,13 @@
-import _ from 'lodash'
+import _ from 'lodash';
 
-const joinToString = list => _.reduce(list, (all, i) => all + i + '\n', '')
+const joinToString = list => _.reduce(list, (all, i) => `${all + i}\n`, '');
 export const vueIndexTs = (extraImports = []) => `import Vue from 'vue';
 import App from './App';
 ${joinToString(extraImports)}
 new Vue({
   el: '#app',
   render: h => h(App),
-});`
+});`;
 export const vueIndexAppVue = styling => `
 <template>
   <div>
@@ -28,7 +28,7 @@ export const vueIndexAppVue = styling => `
 </script>
 
 ${styling}
-`
+`;
 
 export const vueHelloWorldTS = `<template>
     <div>
@@ -62,7 +62,7 @@ export default Vue.extend({
     }
 });
 </script>
-`
+`;
 
 export const vueHelloWorldJs = `<template>
     <div>
@@ -96,11 +96,11 @@ export default Vue.extend({
     }
 });
 </script>
-`
+`;
 
 export const vueShimType = `
 declare module "*.vue" {
   import Vue from 'vue'
   export default Vue
 }
-`
+`;

--- a/src/vendor/PrismLineHighlight.js
+++ b/src/vendor/PrismLineHighlight.js
@@ -1,82 +1,82 @@
 /* eslint-disable */
 
-;(function() {
+(function() {
   if (
     typeof self === 'undefined' ||
     !self.Prism ||
     !self.document ||
     !document.querySelector
   ) {
-    return
+    return;
   }
 
   function $$(expr, con) {
-    return Array.prototype.slice.call((con || document).querySelectorAll(expr))
+    return Array.prototype.slice.call((con || document).querySelectorAll(expr));
   }
 
   function hasClass(element, className) {
-    className = ' ' + className + ' '
+    className = ' ' + className + ' ';
     return (
       (' ' + element.className + ' ')
         .replace(/[\n\t]/g, ' ')
         .indexOf(className) > -1
-    )
+    );
   }
 
   // Some browsers round the line-height, others don't.
   // We need to test for it to position the elements properly.
   var isLineHeightRounded = (function() {
-    var res
+    var res;
     return function() {
       if (typeof res === 'undefined') {
-        var d = document.createElement('div')
-        d.style.fontSize = '13px'
-        d.style.lineHeight = '1.5'
-        d.style.padding = 0
-        d.style.border = 0
-        d.innerHTML = '&nbsp;<br />&nbsp;'
-        document.body.appendChild(d)
+        var d = document.createElement('div');
+        d.style.fontSize = '13px';
+        d.style.lineHeight = '1.5';
+        d.style.padding = 0;
+        d.style.border = 0;
+        d.innerHTML = '&nbsp;<br />&nbsp;';
+        document.body.appendChild(d);
         // Browsers that round the line-height should have offsetHeight === 38
         // The others should have 39.
-        res = d.offsetHeight === 38
-        document.body.removeChild(d)
+        res = d.offsetHeight === 38;
+        document.body.removeChild(d);
       }
-      return res
-    }
-  })()
+      return res;
+    };
+  })();
 
   function highlightLines(pre, lines, classes) {
-    lines = typeof lines === 'string' ? lines : pre.getAttribute('data-line')
+    lines = typeof lines === 'string' ? lines : pre.getAttribute('data-line');
 
     var ranges = lines.replace(/\s+/g, '').split(','),
-      offset = +pre.getAttribute('data-line-offset') || 0
+      offset = +pre.getAttribute('data-line-offset') || 0;
 
-    var parseMethod = isLineHeightRounded() ? parseInt : parseFloat
-    var lineHeight = parseMethod(getComputedStyle(pre).lineHeight)
-    var hasLineNumbers = hasClass(pre, 'line-numbers')
+    var parseMethod = isLineHeightRounded() ? parseInt : parseFloat;
+    var lineHeight = parseMethod(getComputedStyle(pre).lineHeight);
+    var hasLineNumbers = hasClass(pre, 'line-numbers');
 
     for (var i = 0, currentRange; (currentRange = ranges[i++]); ) {
-      var range = currentRange.split('-')
+      var range = currentRange.split('-');
 
       var start = +range[0],
-        end = +range[1] || start
+        end = +range[1] || start;
 
       var line =
         pre.querySelector(
           '.line-highlight[data-range="' + currentRange + '"]'
-        ) || document.createElement('div')
+        ) || document.createElement('div');
 
-      line.setAttribute('aria-hidden', 'true')
-      line.setAttribute('data-range', currentRange)
-      line.className = (classes || '') + 'line-highlight'
+      line.setAttribute('aria-hidden', 'true');
+      line.setAttribute('data-range', currentRange);
+      line.className = (classes || '') + 'line-highlight';
 
       //if the line-numbers plugin is enabled, then there is no reason for this plugin to display the line numbers
       if (hasLineNumbers && Prism.plugins.lineNumbers) {
-        var startNode = Prism.plugins.lineNumbers.getLine(pre, start)
-        var endNode = Prism.plugins.lineNumbers.getLine(pre, end)
+        var startNode = Prism.plugins.lineNumbers.getLine(pre, start);
+        var endNode = Prism.plugins.lineNumbers.getLine(pre, end);
 
         if (startNode) {
-          line.style.top = startNode.offsetTop + 'px'
+          line.style.top = startNode.offsetTop + 'px';
         }
 
         if (endNode) {
@@ -84,67 +84,67 @@
             endNode.offsetTop -
             startNode.offsetTop +
             endNode.offsetHeight +
-            'px'
+            'px';
         }
       } else {
-        line.setAttribute('data-start', start)
+        line.setAttribute('data-start', start);
 
         if (end > start) {
-          line.setAttribute('data-end', end)
+          line.setAttribute('data-end', end);
         }
 
-        line.style.top = (start - offset - 1) * lineHeight + 'px'
+        line.style.top = (start - offset - 1) * lineHeight + 'px';
 
-        line.textContent = new Array(end - start + 2).join(' \n')
+        line.textContent = new Array(end - start + 2).join(' \n');
       }
 
       //allow this to play nicely with the line-numbers plugin
       if (hasLineNumbers) {
         //need to attack to pre as when line-numbers is enabled, the code tag is relatively which screws up the positioning
-        pre.appendChild(line)
+        pre.appendChild(line);
       } else {
-        ;(pre.querySelector('code') || pre).appendChild(line)
+        (pre.querySelector('code') || pre).appendChild(line);
       }
     }
   }
 
   function applyHash() {
-    var hash = location.hash.slice(1)
+    var hash = location.hash.slice(1);
 
     // Remove pre-existing temporary lines
     $$('.temporary.line-highlight').forEach(function(line) {
-      line.parentNode.removeChild(line)
-    })
+      line.parentNode.removeChild(line);
+    });
 
-    var range = (hash.match(/\.([\d,-]+)$/) || [, ''])[1]
+    var range = (hash.match(/\.([\d,-]+)$/) || [, ''])[1];
 
     if (!range || document.getElementById(hash)) {
-      return
+      return;
     }
 
     var id = hash.slice(0, hash.lastIndexOf('.')),
-      pre = document.getElementById(id)
+      pre = document.getElementById(id);
 
     if (!pre) {
-      return
+      return;
     }
 
     if (!pre.hasAttribute('data-line')) {
-      pre.setAttribute('data-line', '')
+      pre.setAttribute('data-line', '');
     }
 
-    highlightLines(pre, range, 'temporary ')
+    highlightLines(pre, range, 'temporary ');
 
-    document.querySelector('.temporary.line-highlight').scrollIntoView()
+    document.querySelector('.temporary.line-highlight').scrollIntoView();
   }
 
-  var fakeTimer = 0 // Hack to limit the number of times applyHash() runs
+  var fakeTimer = 0; // Hack to limit the number of times applyHash() runs
 
   Prism.hooks.add('before-sanity-check', function(env) {
-    var pre = env.element.parentNode
+    var pre = env.element.parentNode;
 
     if (!pre || !/pre/i.test(pre.nodeName)) {
-      return
+      return;
     }
 
     /*
@@ -154,49 +154,49 @@
      * to cleanup any left-over tags, because the whitespace inside of the <div> //
      * tags change the content of the <code> tag. //
      */
-    var num = 0
+    var num = 0;
 
     $$('.line-highlight', pre).forEach(function(line) {
-      num += line.textContent.length
-      line.parentNode.removeChild(line)
-    })
+      num += line.textContent.length;
+      line.parentNode.removeChild(line);
+    });
 
     // Remove extra whitespace
     if (num && /^( \n)+$/.test(env.code.slice(-num))) {
-      env.code = env.code.slice(0, -num)
+      env.code = env.code.slice(0, -num);
     }
-  })
+  });
 
   Prism.hooks.add('complete', function completeHook(env) {
-    var pre = env.element.parentNode
-    var lines = pre && pre.getAttribute('data-line')
+    var pre = env.element.parentNode;
+    var lines = pre && pre.getAttribute('data-line');
 
     if (!pre || !lines || !/pre/i.test(pre.nodeName)) {
-      return
+      return;
     }
 
-    clearTimeout(fakeTimer)
+    clearTimeout(fakeTimer);
 
-    var hasLineNumbers = Prism.plugins.lineNumbers
-    var isLineNumbersLoaded = env.plugins && env.plugins.lineNumbers
+    var hasLineNumbers = Prism.plugins.lineNumbers;
+    var isLineNumbersLoaded = env.plugins && env.plugins.lineNumbers;
 
     if (
       hasClass(pre, 'line-numbers') &&
       hasLineNumbers &&
       !isLineNumbersLoaded
     ) {
-      Prism.hooks.add('line-numbers', completeHook)
+      Prism.hooks.add('line-numbers', completeHook);
     } else {
-      highlightLines(pre, lines)
-      fakeTimer = setTimeout(applyHash, 1)
+      highlightLines(pre, lines);
+      fakeTimer = setTimeout(applyHash, 1);
     }
-  })
+  });
 
-  window.addEventListener('hashchange', applyHash)
+  window.addEventListener('hashchange', applyHash);
   window.addEventListener('resize', function() {
-    var preElements = document.querySelectorAll('pre[data-line]')
+    var preElements = document.querySelectorAll('pre[data-line]');
     Array.prototype.forEach.call(preElements, function(pre) {
-      highlightLines(pre)
-    })
-  })
-})()
+      highlightLines(pre);
+    });
+  });
+})();

--- a/src/vendor/prism-line-highlight.css
+++ b/src/vendor/prism-line-highlight.css
@@ -1,21 +1,20 @@
 pre[data-line] {
-    position: relative;
-
+  position: relative;
 }
 
 .line-highlight {
-    position: absolute;
-    left: 0;
-    right: 0;
-    margin-left: 7px;
-    margin-right: 7px;
-    margin-top: 1em;
+  position: absolute;
+  left: 0;
+  right: 0;
+  margin-left: 7px;
+  margin-right: 7px;
+  margin-top: 1em;
 
-    box-shadow: 0 0 10pt 2pt #145B98;
-    border-radius: 10px;
+  box-shadow: 0 0 10pt 2pt #145b98;
+  border-radius: 10px;
 
-    pointer-events: none;
+  pointer-events: none;
 
-    line-height: inherit;
-    white-space: pre;
+  line-height: inherit;
+  white-space: pre;
 }


### PR DESCRIPTION
Hello @jakoblind 

As mentioned in #56 , 

`lint-staged` itself installing `husky`, which seems to trigger the hooks. You can find the document [here](https://github.com/okonet/lint-staged#installation-and-setup)
- I have added the packages.
- Fixed some auto-fixable lint issues by running `prettier --write`. 
- There are 240+ error altogether, for now I updated eslint rules such that they will be ignored. We should fix them some at a time. Below are the high priority ones and having more errors
  * `react/prop-types` - having 90 errors. We should define `propTypes` for all components.
  * `react/destructuring-assignment` - having 34 errors.
- Fixed high vulnerability with `parcel-bundler` by upgrading with `npm audit fix`.