### PR TITLE
Added propTypes for all components to align with react/prop-types

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,6 @@
     "import/prefer-default-export": ["off"],
     "react/no-unescaped-entities": ["off"],
     "global-require": ["off"],
-    "react/prop-types": ["off"],
     "max-classes-per-file": ["off"],
     "no-unused-vars": ["off"],
     "no-shadow": ["off"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -11801,13 +11801,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -11820,18 +11818,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -11934,8 +11929,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -11945,7 +11939,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -11958,7 +11951,6 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -12058,8 +12050,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -12069,7 +12060,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -12175,7 +12165,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -78,14 +78,14 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged",
+      "pre-push": "npm test"
     }
   },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx}": [
       "eslint --fix",
       "prettier —-write",
-      "npm test",
       "git add"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged",
-      "pre-push": "npm test"
+      "pre-push": "npm run test"
     }
   },
   "lint-staged": {

--- a/src/components/DocsViewer.js
+++ b/src/components/DocsViewer.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 import styles from '../styles.module.css';
 
@@ -308,3 +309,15 @@ export default function DocsViewer({
 
   return <div className={styles.docsContainer}>{theDoc}</div>;
 }
+
+DocsViewer.propTypes = {
+  hoverFeature: PropTypes.string,
+  selectedFeatures: PropTypes.arrayOf(PropTypes.string),
+  buildTool: PropTypes.string,
+};
+
+DocsViewer.defaultProps = {
+  hoverFeature: '',
+  selectedFeatures: [],
+  buildTool: '',
+};

--- a/src/components/FileBrowser.js
+++ b/src/components/FileBrowser.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 
 import '../vendor/prism-line-highlight.css';
@@ -66,6 +67,19 @@ const FileList = ({ files, selectedFile, onSelectFile }) => {
   );
 };
 
+FileList.propTypes = {
+  files: PropTypes.shape({
+    content: PropTypes.string,
+    highlightedFile: PropTypes.bool,
+  }).isRequired,
+  selectedFile: PropTypes.string,
+  onSelectFile: PropTypes.func.isRequired,
+};
+
+FileList.defaultProps = {
+  selectedFile: '',
+};
+
 class CodeBox extends React.Component {
   componentDidMount() {
     Prism.highlightAll();
@@ -82,7 +96,6 @@ class CodeBox extends React.Component {
 
   render() {
     const { code, highlightedLines } = this.props;
-
     return (
       <div className={styles.codeBox}>
         <pre className={styles.codeBoxPre} data-line={highlightedLines}>
@@ -93,9 +106,18 @@ class CodeBox extends React.Component {
   }
 }
 
+CodeBox.propTypes = {
+  code: PropTypes.string,
+  highlightedLines: PropTypes.string,
+};
+
+CodeBox.defaultProps = {
+  highlightedLines: '',
+  code: '',
+};
+
 const filenameRegex = /.+\./i;
 const extensionRegex = /\.[0-9a-z]+$/i;
-
 class FileBrowser extends React.Component {
   constructor(props) {
     super(props);
@@ -158,6 +180,15 @@ class FileBrowser extends React.Component {
     );
   }
 }
+
+FileBrowser.propTypes = {
+  fileContentMap: PropTypes.shape({
+    content: PropTypes.string,
+    highlightedFile: PropTypes.bool,
+  }).isRequired,
+  defaultSelection: PropTypes.string.isRequired,
+  onSelectPackageJson: PropTypes.func.isRequired,
+};
 /*
  This component takes files as props.
   files is an object with file names as keys, and a map as value.
@@ -202,6 +233,15 @@ class FileBrowserTransformer extends React.Component {
     );
   }
 }
+
+FileBrowserTransformer.propTypes = {
+  files: PropTypes.shape({
+    content: PropTypes.string,
+    highlightedFile: PropTypes.bool,
+  }).isRequired,
+  onSelectPackageJson: PropTypes.func.isRequired,
+  defaultSelection: PropTypes.string.isRequired,
+};
 
 class FileBrowserContainer extends React.Component {
   constructor(props) {
@@ -291,7 +331,6 @@ class FileBrowserContainer extends React.Component {
 
   render() {
     const { projectFiles } = this.state;
-
     const files = _.mapValues(projectFiles, (currentContent, file) => {
       let previousContent;
       if (this.state.projectFilesWithoutHighlightedFeature[file]) {
@@ -308,11 +347,31 @@ class FileBrowserContainer extends React.Component {
     return (
       <FileBrowserTransformer
         onSelectPackageJson={() => this.setProjectFilesInState()}
-        defaultSelection={this.props.defaultFile || 'webpack.config.js'}
+        defaultSelection={this.props.defaultFile}
         files={files}
       />
     );
   }
 }
+
+FileBrowserContainer.propTypes = {
+  files: PropTypes.shape({
+    content: PropTypes.string,
+    highlightedFile: PropTypes.bool,
+  }),
+  defaultFile: PropTypes.string,
+
+  featureConfig: PropTypes.shape({
+    features: PropTypes.shape({}).isRequired,
+  }).isRequired,
+  features: PropTypes.arrayOf(PropTypes.string).isRequired,
+  highlightFeature: PropTypes.string,
+  projectGeneratorFunction: PropTypes.func.isRequired,
+};
+FileBrowserContainer.defaultProps = {
+  defaultFile: 'webpack.config.js',
+  files: {},
+  highlightFeature: '',
+};
 
 export default FileBrowserContainer;

--- a/src/components/SignupForms.js
+++ b/src/components/SignupForms.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import styles from '../styles.module.css';
 
 /* DRIP form. currently not in use. */
@@ -33,7 +34,7 @@ const SignupForm = ({ buttonText, buttonStyle, signupText, dripId }) => (
         <input
           className={buttonStyle || styles.myButton}
           type="submit"
-          value={buttonText || 'Send Me Lesson 1'}
+          value={buttonText}
           data-drip-attribute="sign-up-button"
         />
         <br />
@@ -42,6 +43,19 @@ const SignupForm = ({ buttonText, buttonStyle, signupText, dripId }) => (
     </form>
   </div>
 );
+
+SignupForm.propTypes = {
+  buttonText: PropTypes.string,
+  buttonStyle: PropTypes.string,
+  signupText: PropTypes.string,
+  dripId: PropTypes.string.isRequired,
+};
+
+SignupForm.defaultProps = {
+  buttonText: 'Send Me Lesson 1',
+  buttonStyle: '',
+  signupText: '',
+};
 
 function ConvertKitSignupForm({
   children,
@@ -126,6 +140,25 @@ function ConvertKitSignupForm({
   );
 }
 
+ConvertKitSignupForm.propTypes = {
+  buttonText: PropTypes.string,
+  buttonStyle: PropTypes.string,
+  signupText: PropTypes.string,
+  formId: PropTypes.string.isRequired,
+  tags: PropTypes.number.isRequired,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
+};
+
+ConvertKitSignupForm.defaultProps = {
+  buttonText: 'Send Me Lesson 1',
+  buttonStyle: '',
+  signupText: '',
+  children: [],
+};
+
 export function withHidden(WrappedComponent, text) {
   return class extends React.Component {
     constructor(props) {
@@ -163,10 +196,35 @@ export const SampleChapterSignupForm = ({ buttonText }) => (
   />
 );
 
+SampleChapterSignupForm.propTypes = {
+  buttonText: PropTypes.string,
+};
+
+SampleChapterSignupForm.defaultProps = {
+  buttonText: 'Send me a sample chapter',
+};
+
 export const GenericSignupForm = ({ buttonText }) => (
-  <ConvertKitSignupForm buttonText="Sign up" formId="931959" />
+  <ConvertKitSignupForm buttonText={buttonText} formId="931959" />
 );
+
+GenericSignupForm.propTypes = {
+  buttonText: PropTypes.string,
+};
+
+GenericSignupForm.defaultProps = {
+  buttonText: 'Sign up',
+};
 
 export const CourseSignupForm = ({ buttonText, tags }) => (
   <ConvertKitSignupForm buttonText={buttonText} formId="917789" tags={tags} />
 );
+
+CourseSignupForm.propTypes = {
+  buttonText: PropTypes.string,
+  tags: PropTypes.number.isRequired,
+};
+
+CourseSignupForm.defaultProps = {
+  buttonText: 'Sign up',
+};

--- a/src/components/configurator/Features.js
+++ b/src/components/configurator/Features.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 import Modal from 'react-modal';
 import styles from '../../styles.module.css';
@@ -56,6 +57,18 @@ function FeedbackForm({ feature, children }) {
   return <>{isSent ? thankYouMessage : form}</>;
 }
 
+FeedbackForm.propTypes = {
+  feature: PropTypes.string.isRequired,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
+};
+
+FeedbackForm.defaultProps = {
+  children: [],
+};
+
 function FeatureHelp({ featureName, selectedBuildTool }) {
   const [modalOpen, setModalOpen] = useState(false);
   const helpText = docsMap(selectedBuildTool)[featureName];
@@ -93,6 +106,12 @@ function FeatureHelp({ featureName, selectedBuildTool }) {
     </>
   );
 }
+
+FeatureHelp.propTypes = {
+  featureName: PropTypes.string.isRequired,
+  selectedBuildTool: PropTypes.string.isRequired,
+};
+
 const Feature = ({
   feature,
   selected,
@@ -121,6 +140,20 @@ const Feature = ({
     <FeatureHelp featureName={feature} selectedBuildTool={selectedBuildTool} />
   </>
 );
+
+Feature.propTypes = {
+  feature: PropTypes.string.isRequired,
+  selected: PropTypes.bool,
+  setSelected: PropTypes.func.isRequired,
+  onMouseEnter: PropTypes.func.isRequired,
+  onMouseLeave: PropTypes.func.isRequired,
+  selectedBuildTool: PropTypes.string.isRequired,
+};
+
+Feature.defaultProps = {
+  selected: false,
+};
+
 function usePrevious(value) {
   const ref = useRef();
   useEffect(() => {
@@ -183,6 +216,22 @@ function FeatureGroup({
   );
 }
 
+const packageJsonShape = PropTypes.shape({});
+
+FeatureGroup.propTypes = PropTypes.shape({
+  featureList: PropTypes.arrayOf(
+    PropTypes.shape({
+      feature: PropTypes.string.isRequired,
+      group: PropTypes.string.isRequired,
+      packageJson: packageJsonShape.isRequired,
+      webpackImports: PropTypes.arrayOf(PropTypes.any).isRequired,
+    }).isRequired
+  ).isRequired,
+  group: PropTypes.string.isRequired,
+  selected: packageJsonShape.isRequired,
+  selectedBuildTool: PropTypes.string.isRequired,
+}).isRequired;
+
 export default class Features extends React.Component {
   render() {
     const {
@@ -216,6 +265,18 @@ export default class Features extends React.Component {
     );
   }
 }
+
+const feautureShape = PropTypes.shape({
+  group: PropTypes.string.isRequired,
+  packageJson: packageJsonShape.isRequired,
+  webpackImports: PropTypes.arrayOf(PropTypes.any).isRequired,
+});
+
+Features.propTypes = PropTypes.shape({
+  features: PropTypes.objectOf(feautureShape).isRequired,
+  selected: packageJsonShape.isRequired,
+  selectedBuildTool: PropTypes.string.isRequired,
+}).isRequired;
 
 /*
   only possible to select one of Vue or React. Needing both is an edge case

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'gatsby';
 
 const Header = ({ siteTitle }) => (
@@ -18,5 +19,9 @@ const Header = ({ siteTitle }) => (
     </div>
   </div>
 );
+
+Header.propTypes = {
+  siteTitle: PropTypes.string.isRequired,
+};
 
 export default Header;

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -100,6 +100,13 @@ const Layout = ({ children, title, metaDescription }) => (
 
 Layout.propTypes = {
   children: PropTypes.node.isRequired,
+  title: PropTypes.string,
+  metaDescription: PropTypes.string,
+};
+
+Layout.defaultProps = {
+  title: '',
+  metaDescription: '',
 };
 
 export default Layout;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,5 @@
 import React, { useState, useReducer } from 'react';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { Link } from 'gatsby';
 import Modal from 'react-modal';
@@ -109,6 +110,17 @@ const StepByStepArea = ({ features, newBabelConfig, isReact, isWebpack }) => {
   );
 };
 
+StepByStepArea.propTypes = {
+  features: PropTypes.arrayOf(PropTypes.string).isRequired,
+  newBabelConfig: PropTypes.string,
+  isReact: PropTypes.bool.isRequired,
+  isWebpack: PropTypes.bool.isRequired,
+};
+
+StepByStepArea.defaultProps = {
+  newBabelConfig: null, // createBabelConfig function returns null if babel is not selected
+};
+
 function Tabs({ selected, setSelected }) {
   return (
     <div className={styles.tabsContainer} id="tabs">
@@ -147,6 +159,11 @@ function Tabs({ selected, setSelected }) {
     </div>
   );
 }
+
+Tabs.propTypes = {
+  selected: PropTypes.string.isRequired,
+  setSelected: PropTypes.func.isRequired,
+};
 
 Modal.setAppElement('#___gatsby');
 
@@ -214,6 +231,16 @@ function DownloadButton({ url, onClick, filename }) {
     </div>
   );
 }
+
+DownloadButton.propTypes = {
+  url: PropTypes.string,
+  filename: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
+};
+
+DownloadButton.defaultProps = {
+  url: '',
+};
 
 const selectionRules = {
   stopSelectFunctions: [
@@ -345,7 +372,7 @@ function Configurator(props) {
     reducer,
     initialState(props.selectedTab)
   );
-  const [hoverFeature, setHoverFeature] = useState({});
+  const [hoverFeature, setHoverFeature] = useState('');
 
   const {
     featureConfig,
@@ -473,6 +500,14 @@ function Configurator(props) {
   );
 }
 
+Configurator.propTypes = {
+  selectedTab: PropTypes.string,
+};
+
+Configurator.defaultProps = {
+  selectedTab: 'webpack',
+};
+
 export class App extends React.Component {
   joyrideCallback({ lifecycle, step: { target } }) {
     if (lifecycle === 'tooltip') {
@@ -497,5 +532,17 @@ export class App extends React.Component {
     );
   }
 }
+
+App.propTypes = {
+  pageContext: PropTypes.shape({
+    selectedTab: PropTypes.string,
+  }),
+};
+
+App.defaultProps = {
+  pageContext: {
+    selectedTab: 'webpack',
+  },
+};
 
 export default App;


### PR DESCRIPTION
Hello @jakoblind 

This PR includes below changes:
- Added propTypes for all components to align with `react/prop-types`
- Removed `react/prop-types` eslint rule which is turned off. From now on, it will enforce components to have propTypes.
- Moved `npm run test` to `pre-push` hook.
