### PR TITLE
Fixed #60

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11801,11 +11801,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -11818,15 +11820,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -11929,7 +11934,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -11939,6 +11945,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -11951,17 +11958,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -11978,6 +11988,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -12050,7 +12061,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -12060,6 +12072,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -12165,6 +12178,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,0 +1,5 @@
+import Modal from 'react-modal';
+
+Modal.defaultStyles.overlay.zIndex = 101; // ISSUE-60 Fix
+
+export default Modal;

--- a/src/components/configurator/Features.js
+++ b/src/components/configurator/Features.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import Modal from 'react-modal';
+import Modal from '../Modal';
 import styles from '../../styles.module.css';
 import { docsMap } from '../DocsViewer';
 import { gaSendEvent } from '../../googleAnalytics';

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,10 +2,10 @@ import React, { useState, useReducer } from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { Link } from 'gatsby';
-import Modal from 'react-modal';
 import jszip from 'jszip';
 import Joyride from 'react-joyride';
 import { saveAs } from 'file-saver';
+import Modal from '../components/Modal';
 import styles from '../styles.module.css';
 import npmVersionPromise from '../fetch-npm-version';
 


### PR DESCRIPTION
@jakoblind 

This PR fixes issue #60 

- Joyride beacon is having `zIndex=100`, so I am setting react modal overlay `zIndex` to `101` which fixes the issue. 
- Created `components/Modal.js` as wrapper for react-modal component so that we don't need to update zIndex wherever we need a modal.
- Updated the modal imports with our wrapper modal component i.e.`components/Modal.js`