### PR TITLE
Added Webpack Dev Server to Vanilla JS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11801,13 +11801,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -11820,18 +11818,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -11934,8 +11929,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -11945,7 +11939,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -11958,20 +11951,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -11988,7 +11978,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -12061,8 +12050,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -12072,7 +12060,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -12178,7 +12165,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/configurator/webpack-config/index.js
+++ b/src/configurator/webpack-config/index.js
@@ -399,9 +399,10 @@ export default (() => {
         scripts: {
           'build-dev': 'webpack -d --mode development',
           'build-prod': 'webpack -p --mode production',
+          start: 'webpack-dev-server --hot --mode development',
         },
       },
-      devDependencies: ['webpack', 'webpack-cli'],
+      devDependencies: ['webpack', 'webpack-cli', 'webpack-dev-server'],
       files: configItems => {
         const isTypescript = _.includes(configItems, 'Typescript');
         const extraImports = getStyleImports(configItems);

--- a/src/templates/base.js
+++ b/src/templates/base.js
@@ -4,6 +4,9 @@ export const baseWebpack = {
     path: "CODE:path.resolve(__dirname, 'dist')",
     filename: 'bundle.js',
   },
+  devServer: {
+    contentBase: './dist',
+  },
 };
 
 export const baseWebpackImports = [


### PR DESCRIPTION
Hello @jakoblind 

This is to support use case mentioned in #41.

#### Summary of this PR:
- [x] Added `webpack-dev-server` `start` script to Vanilla JS projects.
- [x] Same script is working great for VueJS project as well.
- [x] Added `devServer` config to Vanilla JS project to serve the correct directory, earlier it was serving the project root, which is shown in below screenshot.

<img width="897" alt="Screenshot 2019-10-21 at 3 23 29 PM" src="https://user-images.githubusercontent.com/11477078/67214734-ded20900-f43d-11e9-892e-0ddb41a88414.png">


Please review and merge.
