### PR TITLE
Change Webpack TypeScript loader

### DIFF
--- a/src/configurator/webpack-config/index.js
+++ b/src/configurator/webpack-config/index.js
@@ -198,7 +198,7 @@ export default (() => {
     Typescript: {
       group: 'Transpiler',
       devDependencies: configItems => {
-        const devDepList = ['typescript', 'awesome-typescript-loader'];
+        const devDepList = ['typescript', 'ts-loader'];
         if (_.includes(configItems, 'React hot loader'))
           devDepList.push('@hot-loader/react-dom');
         return devDepList;
@@ -207,7 +207,7 @@ export default (() => {
         const isVue = _.includes(configItems, 'Vue');
         const typescriptModule = {
           test: /\.ts(x)?$/,
-          use: ['awesome-typescript-loader'],
+          use: ['ts-loader'],
           exclude: /node_modules/,
         };
         if (isVue) {


### PR DESCRIPTION
A simple change for using the recommended `ts-loader` instead the `awesome-typescript-loader`.

See how Webpack's [TypeScript documentation](https://webpack.js.org/guides/typescript/) indicates to use `ts-loader` too.

Also see https://www.npmtrends.com/awesome-typescript-loader-vs-ts-loader for latest usage trends.

No major changes needed (I think).

Related to #79 