### PR TITLE
Fixing typos

### DIFF
--- a/src/pages/parcel-course.js
+++ b/src/pages/parcel-course.js
@@ -7,7 +7,7 @@ export default () => {
   return (
     <Layout title="Free Parcel course">
       <div className={styles.webpackConfigContainer}>
-        <h1 className={styles.large}>Free Parcel course - comming soon</h1>
+        <h1 className={styles.large}>Free Parcel course - coming soon</h1>
         <p>
           I am working on creating a free Parcel email course. Sign up below and
           I'll let you know when it's done. In the meantime I'll send you new

--- a/src/pages/webpack-book.js
+++ b/src/pages/webpack-book.js
@@ -100,7 +100,7 @@ export default () => {
           To create a simple hello world app with webpack, you have to install
           LOTs of dependencies. First, there's <code>webpack</code>, which is
           fine. You already expected to install that. But then you
-          <i>also</i> have to install all of the following:
+           <i>also</i> have to install all of the following:
         </p>
         <ul>
           <li>


### PR DESCRIPTION
- Noticed an extra 'm' on the Parcel course page
- Missing space on the Webpack book page