### PR TITLE
change vue2 init codes to vue3

### DIFF
--- a/src/configurator/webpack-config/index.js
+++ b/src/configurator/webpack-config/index.js
@@ -116,7 +116,7 @@ export default (() => {
       name: 'Vue',
       group: 'Main library',
       webpackImports: [
-        "const VueLoaderPlugin = require('vue-loader/lib/plugin');",
+        "const { VueLoaderPlugin } = require('vue-loader');",
       ],
       webpack: (webpackConfig) => {
         const webpackConfigWithRule = assignModuleRuleAndResolver(
@@ -149,7 +149,7 @@ export default (() => {
             'src/App.vue': vueIndexAppVue(_.join(styling, '\n'), configItems),
             [indexFilename]: vueIndexTs(),
           },
-          isTypescript ? { 'vue-shim.d.ts': vueShimType } : {}
+          isTypescript ? { 'src/vue-shim.d.ts': vueShimType } : {}
         );
       },
     },

--- a/src/templates/vue/index.js
+++ b/src/templates/vue/index.js
@@ -1,20 +1,17 @@
 import _ from 'lodash';
 
-const joinToString = list => _.reduce(list, (all, i) => `${all + i}\n`, '');
+const joinToString = (list) => _.reduce(list, (all, i) => `${all + i}\n`, '');
 
-export const vueIndexTs = (extraImports = []) => `import Vue from 'vue';
-import App from './App';
+export const vueIndexTs = (extraImports = []) => `import { createApp } from 'vue';
+import App from './App.vue';
 ${joinToString(extraImports)}
-new Vue({
-  el: '#app',
-  render: h => h(App),
-});`;
+createApp(App).mount("#app");`;
 
 export const vueIndexAppVue = (styling, configItems) => {
   const isTailwindcss = _.includes(configItems, 'tailwind-css');
   const isBootstrap = _.includes(configItems, 'bootstrap');
-  return `
-<template>
+  const isTypescript = _.includes(configItems, 'typescript');
+  return `<template>
   <div>
     <h1${isTailwindcss ? ' class="text-4xl text-white bg-black"' : ''}>
       {{name}}
@@ -27,30 +24,35 @@ export const vueIndexAppVue = (styling, configItems) => {
     }
   </div>
 </template>
-
-<script lang="ts">
-  import Vue from "vue";${
-    isBootstrap
-      ? `\n  import 'bootstrap';\n  import 'bootstrap/dist/css/bootstrap.min.css';`
-      : ''
-  }
-
-  export default Vue.extend({
-    data: function() {
-      return {
-        name: 'Hello World!',
-      }
-    },
-  });
+${
+  isTypescript 
+  ? '<script lang="ts">\n' 
+  : '<script>'
+}${
+  isTypescript 
+    ? 'import { defineComponent } from \'vue\'\n' 
+    : ''
+}${
+  isBootstrap
+    ? `\n  import 'bootstrap';\n  import 'bootstrap/dist/css/bootstrap.min.css';`
+    : ''
+}
+export default ${isTypescript ? 'defineComponent(' : ''}{
+  data: function() {
+    return {
+      name: 'Hello World!',
+    }
+  },
+}${isTypescript ? ')' : ''};
 </script>
 
 ${styling}
 `;
 };
 
-export const vueShimType = `
-declare module "*.vue" {
-  import Vue from 'vue'
-  export default Vue
+export const vueShimType = `declare module "*.vue" {
+  import type { DefineComponent } from "vue";
+  const component: DefineComponent<{}, {}, any>;
+  export default component;
 }
 `;


### PR DESCRIPTION
Vue 3 has some differences mounting root component to DOM with Vue 2, and so are Vue 3 with TypeScript build and VueLoaderPlugin. createapp.dev is not available for using vue as starting framework, so I changed some of the initial vue project codes to fix these issues.